### PR TITLE
feat: 允许 API 和 WebSocket 地址留空以使用同源模式，并为开发环境添加代理配置。

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,15 +166,12 @@ yarn dev
 ```
 
 开发服务器默认运行在 `http://localhost:5173`，支持热模块替换（HMR）。
+默认已配置 API 代理到 `http://localhost:60000`（覆盖 `/assets`、`/index`、`/novel` 等后端路由前缀），可直接使用同源相对路径请求。
 
 ### 4. 构建生产版本
 
 ```bash
-# 开发环境构建
-yarn build:dev
-
-# 生产环境构建
-yarn build:prod
+yarn build
 ```
 
 构建产物将输出到 `dist` 目录。
@@ -194,7 +191,7 @@ yarn preview
 1. **构建项目**
 
 ```bash
-yarn build:prod
+yarn build
 ```
 
 2. **部署到 Web 服务器**
@@ -214,18 +211,15 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # API 代理（可选）
-    location /api/ {
-        proxy_pass http://localhost:60000/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-    }
+    # 单页应用路由回退
+    error_page 404 /index.html;
 }
 ```
 
 ### 方式二：与后端集成部署
 
 将构建后的 `dist` 目录内容复制到后端的静态资源目录 `scripts/web` 中。
+后端 `Toonflow-app` 在 Web 模式下会由 Express 同时提供前端和 API，统一入口为 `http://localhost:60000`（Docker 对外默认 `80` 端口）。
 
 > 💡 **提示**：后端服务可从 [GitHub](https://github.com/HBAI-Ltd/Toonflow-app) 或 [Gitee](https://gitee.com/HBAI-Ltd/Toonflow-app) 仓库获取。
 
@@ -256,11 +250,8 @@ yarn lint
 # 代码格式化
 yarn format
 
-# 构建开发版本
-yarn build:dev
-
 # 构建生产版本
-yarn build:prod
+yarn build
 
 # 预览生产构建
 yarn preview

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -1,8 +1,8 @@
 export default defineStore(
   "setting",
   () => {
-    const baseUrl = ref<string>("http://localhost:60000");
-    const wsBaseUrl = ref<string>("ws://localhost:60000");
+    const baseUrl = ref<string>("");
+    const wsBaseUrl = ref<string>("");
 
     const otherSetting = ref({
       axiosTimeOut: 60000 * 10 * 100,

--- a/src/utils/wsClient.ts
+++ b/src/utils/wsClient.ts
@@ -20,8 +20,10 @@ class WsClient {
 
   constructor(url: string, options: WsOptions = {}) {
     const { wsBaseUrl } = storeToRefs(settingStore());
+    const effectiveWsBase =
+      wsBaseUrl.value || `${window.location.protocol === "https:" ? "wss:" : "ws:"}//${window.location.host}`;
 
-    const fullUrl = new URL(url, wsBaseUrl.value);
+    const fullUrl = new URL(url, effectiveWsBase);
     const token = localStorage.getItem("token");
     if (token) fullUrl.searchParams.set("token", token);
     this.url = fullUrl.toString();

--- a/src/views/setting/components/requestConfig.vue
+++ b/src/views/setting/components/requestConfig.vue
@@ -2,14 +2,14 @@
   <div class="request-config">
     <t-form :data="formData" labelAlign="top" :rules="formRules" @submit="handleSubmit">
       <t-form-item label="API 地址" name="baseUrl">
-        <t-input v-model="formData.baseUrl" placeholder="请输入 API 请求地址" clearable>
+        <t-input v-model="formData.baseUrl" placeholder="留空则使用同源模式（当前站点）" clearable>
           <template #prefix-icon>
             <t-icon name="link" />
           </template>
         </t-input>
       </t-form-item>
       <t-form-item label="WebSocket地址" name="wsBaseUrl">
-        <t-input v-model="formData.wsBaseUrl" placeholder="请输入 WebSocket 地址" clearable>
+        <t-input v-model="formData.wsBaseUrl" placeholder="留空则自动推导为同源 WS 地址" clearable>
           <template #prefix-icon>
             <t-icon name="swap" />
           </template>
@@ -44,19 +44,17 @@ const formData = ref<RequestForm>({
 
 const formRules: FormRules<RequestForm> = {
   baseUrl: [
-    { required: true, message: "请输入 API 地址", trigger: "blur" },
-    { 
-      pattern: /^https?:\/\/.+/, 
-      message: "请输入有效的 HTTP/HTTPS 地址", 
-      trigger: "blur" 
+    {
+      validator: (value: string) => !value || /^https?:\/\/.+/.test(value),
+      message: "请输入有效的 HTTP/HTTPS 地址，或留空使用同源模式",
+      trigger: "blur",
     },
   ],
   wsBaseUrl: [
-    { required: true, message: "请输入 WebSocket 地址", trigger: "blur" },
-    { 
-      pattern: /^wss?:\/\/.+/, 
-      message: "请输入有效的 WS/WSS 地址", 
-      trigger: "blur" 
+    {
+      validator: (value: string) => !value || /^wss?:\/\/.+/.test(value),
+      message: "请输入有效的 WS/WSS 地址，或留空自动推导",
+      trigger: "blur",
     },
   ],
 };
@@ -75,11 +73,11 @@ function handleSubmit({ validateResult }: { validateResult: boolean }) {
 }
 
 function handleReset() {
-  formData.value.baseUrl = "http://localhost:60000";
-  formData.value.wsBaseUrl = "ws://localhost:60000";
+  formData.value.baseUrl = "";
+  formData.value.wsBaseUrl = "";
   settingStore.baseUrl = formData.value.baseUrl;
   settingStore.wsBaseUrl = formData.value.wsBaseUrl;
-  MessagePlugin.success("已重置为默认地址");
+  MessagePlugin.success("已重置为同源模式");
 }
 
 onMounted(() => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,14 @@ export default defineConfig({
     }),
     viteSingleFile(),
   ],
+  server: {
+    proxy: {
+      "^/(assets|index|novel|other|outline|project|prompt|script|setting|storyboard|task|user|video)(/|$)": {
+        target: "http://localhost:60000",
+        ws: true,
+      },
+    },
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
# PR: 合并前后端为单端口服务，简化 Docker 部署

## 概述

将 Web 模式下的前端和后端合并为 **单一端口（60000）** 由 Express 同时提供 API 和前端静态文件服务。Docker 部署移除 Nginx / Supervisor / PM2，仅保留单 Node.js 进程。

## 动机

原架构中，生产部署需要 Nginx（80 端口，前端）+ Supervisor + PM2 + Express（60000 端口，API），配置复杂且多进程管理增加了运维负担。前端默认硬编码 `http://localhost:60000`，跨域/跨端口部署时需要用户手动修改配置。

本次改造让 Express 直接服务前端文件，实现单端口单进程部署，同时前端默认使用同源模式，开箱即用。

## 变更内容

### 后端 (`Toonflow-app`)

**`src/app.ts`** — 核心改造
- 新增 `scripts/web` 静态文件服务（放在 JWT 中间件之前，无需认证）
- JWT 中间件增加 API 路径前缀判断，非 API 路径直接放行（前端 SPA 路由）
- 新增 SPA 回退：未匹配的 GET 请求返回 `index.html`
- `isElectron` 提升为模块级常量，所有新增逻辑仅在 `!isElectron` 下生效

**Docker 文件**
| 文件 | 变更 |
|------|------|
| `docker/Dockerfile` | 移除 nginx/supervisor/pm2 安装，前端文件改为 `scripts/web`，CMD 改为直接 `node build/app.js` |
| `docker/Dockerfile.local` | 同上 |
| `docker/docker-compose.yml` | 端口映射改为 `8080:60000`，移除双端口暴露，healthcheck 对齐 60000 |
| `docker/docker-compose.local.yml` | 端口映射改为 `8080:60000`，同上 |

**`README.md`** — 更新文档反映单端口架构

### 前端 (`Toonflow-web`)

**`src/stores/setting.ts`**
- `baseUrl` 和 `wsBaseUrl` 默认值从硬编码地址改为空字符串（同源模式）
- 已有用户 `localStorage` 中的旧值不受影响（`persist: true`）

**`src/utils/wsClient.ts`**
- `wsBaseUrl` 为空时从 `window.location` 自动推导 WebSocket 地址
- 支持 `http → ws` 和 `https → wss` 协议推导

**`src/views/setting/components/requestConfig.vue`**
- 表单验证改为允许空值（空 = 同源模式），保留 URL 格式校验
- 输入框 placeholder 更新为同源模式提示
- 重置按钮改为恢复空值（同源模式）

**`vite.config.ts`**
- 新增开发代理配置，将 API 路径前缀转发到 `http://localhost:60000`
- 正则覆盖有/无尾斜杠两种路径形式，确保 `/index` 等路径正确代理

**`README.md`** — 更新构建命令和部署说明

## 不受影响

- **Electron 模式**：所有新增逻辑由 `isElectron` 守卫，桌面端行为完全不变
- **uploads 静态文件**：挂载优先级高于 web 目录，路径无冲突
- **已有用户设置**：localStorage 中保存的绝对 URL 不受默认值变更影响
- **API 鉴权**：JWT 认证机制不变，匿名范围仅扩展到非 API 路由和前端静态资源

## 架构对比

```
改造前:
  Docker 容器
  ├── Nginx (80)       ← 前端静态文件
  ├── Supervisor       ← 进程管理
  └── PM2 → Express (60000)  ← API

改造后:
  Docker 容器
  └── Node.js → Express (60000)  ← 前端 + API
       对外映射 8080:60000
```

## 变更文件清单

| 仓库 | 文件 | 改动 |
|------|------|------|
| app | `src/app.ts` | 静态服务 + JWT 路径跳过 + SPA 回退 |
| app | `docker/Dockerfile` | 移除 nginx/supervisor/pm2 |
| app | `docker/Dockerfile.local` | 同上 |
| app | `docker/docker-compose.yml` | 单端口 `8080:60000` |
| app | `docker/docker-compose.local.yml` | 单端口 `8080:60000` |
| app | `README.md` | 更新部署说明 |
| web | `src/stores/setting.ts` | 默认值置空 |
| web | `src/utils/wsClient.ts` | 空值时自动推导 WS 地址 |
| web | `src/views/setting/components/requestConfig.vue` | 允许空值 + 文案更新 |
| web | `vite.config.ts` | 开发代理配置 |
| web | `README.md` | 更新构建与部署说明 |
