### PR TITLE
优化请求地址和 WebSocket 地址的设置逻辑，支持运行时默认值和输入规范化

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,31 +21,86 @@ import { storeToRefs } from "pinia";
 const route = useRoute();
 const store = settingStore();
 const { baseUrl, wsBaseUrl } = storeToRefs(store);
+const FALLBACK_HTTP_BASE = "http://localhost:60000";
+const FALLBACK_WS_BASE = "ws://localhost:60000";
 
-// 从 URL query 参数设置请求地址
-const initFromQuery = () => {
+function isFileRuntime(): boolean {
+  const protocol = window.location.protocol || "";
+  const origin = window.location.origin || "";
+  return protocol === "file:" || origin === "null" || !window.location.host;
+}
+
+function getRuntimeBasePath(): string {
+  const pathname = window.location.pathname || "/";
+  const withoutIndex = pathname.replace(/\/index\.html?$/i, "/");
+  const normalized = withoutIndex.replace(/\/+$/, "");
+  return normalized || "/";
+}
+
+function getRuntimeHttpBase(): string {
+  if (isFileRuntime()) return FALLBACK_HTTP_BASE;
+  const basePath = getRuntimeBasePath();
+  return `${window.location.origin}${basePath === "/" ? "" : basePath}`;
+}
+
+function getRuntimeWsBase(): string {
+  if (isFileRuntime()) return FALLBACK_WS_BASE;
+  const basePath = getRuntimeBasePath();
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${window.location.host}${basePath === "/" ? "" : basePath}`;
+}
+
+function shouldResetBaseUrl(value: string): boolean {
+  const normalized = (value || "").trim();
+  return (
+    !normalized ||
+    normalized === "null" ||
+    normalized.startsWith("null/") ||
+    normalized.startsWith("file://") ||
+    normalized === "http://localhost:60000" ||
+    normalized === "http://127.0.0.1:60000"
+  );
+}
+
+function shouldResetWsBaseUrl(value: string): boolean {
+  const normalized = (value || "").trim();
+  return (
+    !normalized ||
+    normalized.startsWith("ws:///") ||
+    normalized.startsWith("wss:///") ||
+    normalized === "ws://localhost:60000" ||
+    normalized === "ws://127.0.0.1:60000"
+  );
+}
+
+function initRuntimeDefaults() {
+  if (shouldResetBaseUrl(baseUrl.value)) {
+    baseUrl.value = getRuntimeHttpBase();
+  }
+  if (shouldResetWsBaseUrl(wsBaseUrl.value)) {
+    wsBaseUrl.value = getRuntimeWsBase();
+  }
+}
+
+function initFromQuery() {
   const query = route.query;
-  console.log('Current query:', query);
-  // 支持通过 ?baseUrl=xxx 设置请求地址
   if (query.baseUrl && typeof query.baseUrl === "string") {
     baseUrl.value = query.baseUrl;
-    console.log('Set baseUrl to:', query.baseUrl);
   }
-  // 支持通过 ?wsBaseUrl=xxx 设置 WebSocket 地址
   if (query.wsBaseUrl && typeof query.wsBaseUrl === "string") {
     wsBaseUrl.value = query.wsBaseUrl;
-    console.log('Set wsBaseUrl to:', query.wsBaseUrl);
   }
-};
-// 监听路由变化，确保 query 参数更新时也能处理
+}
+
 watch(
   () => route.query,
   () => {
+    initRuntimeDefaults();
     initFromQuery();
   },
-  { immediate: true, deep: true }
+  { immediate: true, deep: true },
 );
-// 初始化主题
+
 onMounted(() => {
   initTheme();
 });
@@ -67,9 +122,6 @@ const customConfig: GlobalConfigProvider = {
   pagination: {},
 };
 const globalConfig: GlobalConfigProvider = merge(empty, zhConfig, customConfig);
-
-// document.documentElement.setAttribute('theme-mode', 'dark');
-// document.documentElement.setAttribute('theme-mode', 'light');
 </script>
 
 <style lang="scss">

--- a/src/pages/login/index.vue
+++ b/src/pages/login/index.vue
@@ -7,10 +7,10 @@
       <a-modal v-model:open="showSettingModal" title="服务器设置" @ok="handleSaveSetting" :width="400">
         <a-form :label-col="{ span: 6 }" :wrapper-col="{ span: 18 }">
           <a-form-item label="请求地址">
-            <a-input v-model:value="tempBaseUrl" placeholder="http://localhost:60000" />
+            <a-input v-model:value="tempBaseUrl" placeholder="例如：https://example.com/toonflow" />
           </a-form-item>
           <a-form-item label="WS地址">
-            <a-input v-model:value="tempWsBaseUrl" placeholder="ws://localhost:60000" />
+            <a-input v-model:value="tempWsBaseUrl" placeholder="例如：wss://example.com/toonflow" />
           </a-form-item>
         </a-form>
       </a-modal>

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -1,8 +1,8 @@
 export default defineStore(
   "setting",
   () => {
-    const baseUrl = ref<string>("http://localhost:60000");
-    const wsBaseUrl = ref<string>("ws://localhost:60000");
+    const baseUrl = ref<string>("");
+    const wsBaseUrl = ref<string>("");
 
     const otherSetting = ref({
       axiosTimeOut: 60000 * 10 * 100,

--- a/src/utils/wsClient.ts
+++ b/src/utils/wsClient.ts
@@ -11,6 +11,47 @@ type WsOptions = {
   onError?: (err: any) => void;
 };
 
+function resolveWsBaseUrl(rawValue: string): string {
+  const value = (rawValue || "").trim();
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const hasBrowserHost = window.location.protocol !== "file:" && window.location.origin !== "null" && !!window.location.host;
+  const runtimeHost = hasBrowserHost ? window.location.host : "localhost:60000";
+
+  if (/^wss?:\/\//i.test(value)) {
+    try {
+      const url = new URL(value);
+      if (url.host) return value;
+    } catch {
+      // ignore invalid url and fallback to runtime host
+    }
+  }
+
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      const url = new URL(value);
+      if (url.host) {
+        url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+        return url.toString();
+      }
+    } catch {
+      // ignore invalid url and fallback to runtime host
+    }
+  }
+
+  let pathPrefix = value;
+  if (!pathPrefix || pathPrefix === ".") {
+    pathPrefix = hasBrowserHost ? window.location.pathname : "/";
+  }
+
+  if (!pathPrefix.startsWith("/")) {
+    pathPrefix = `/${pathPrefix}`;
+  }
+
+  pathPrefix = pathPrefix.replace(/\/index\.html?$/i, "/").replace(/\/+$/, "");
+
+  return `${wsProtocol}//${runtimeHost}${pathPrefix}`;
+}
+
 class WsClient {
   public ws: WebSocket | null = null;
   private url: string;
@@ -21,7 +62,10 @@ class WsClient {
   constructor(url: string, options: WsOptions = {}) {
     const { wsBaseUrl } = storeToRefs(settingStore());
 
-    const fullUrl = new URL(url, wsBaseUrl.value);
+    const baseUrl = resolveWsBaseUrl(wsBaseUrl.value);
+    const normalizedPath = url.replace(/^\/+/, "");
+    const fullUrl = new URL(normalizedPath, `${baseUrl.replace(/\/+$/, "")}/`);
+
     const token = localStorage.getItem("token");
     if (token) fullUrl.searchParams.set("token", token);
     this.url = fullUrl.toString();

--- a/src/views/setting/components/requestConfig.vue
+++ b/src/views/setting/components/requestConfig.vue
@@ -2,14 +2,14 @@
   <div class="request-config">
     <t-form :data="formData" labelAlign="top" :rules="formRules" @submit="handleSubmit">
       <t-form-item label="API 地址" name="baseUrl">
-        <t-input v-model="formData.baseUrl" placeholder="请输入 API 请求地址" clearable>
+        <t-input v-model="formData.baseUrl" placeholder="例如：https://example.com/toonflow 或 /toonflow" clearable>
           <template #prefix-icon>
             <t-icon name="link" />
           </template>
         </t-input>
       </t-form-item>
       <t-form-item label="WebSocket地址" name="wsBaseUrl">
-        <t-input v-model="formData.wsBaseUrl" placeholder="请输入 WebSocket 地址" clearable>
+        <t-input v-model="formData.wsBaseUrl" placeholder="例如：wss://example.com/toonflow 或 /toonflow" clearable>
           <template #prefix-icon>
             <t-icon name="swap" />
           </template>
@@ -36,50 +36,103 @@ interface RequestForm {
 }
 
 const settingStore = useSettingStore();
+const FALLBACK_HTTP_BASE = "http://localhost:60000";
+const FALLBACK_WS_BASE = "ws://localhost:60000";
 
 const formData = ref<RequestForm>({
   baseUrl: "",
   wsBaseUrl: "",
 });
 
+function isFileRuntime(): boolean {
+  const protocol = window.location.protocol || "";
+  const origin = window.location.origin || "";
+  return protocol === "file:" || origin === "null" || !window.location.host;
+}
+
+function getRuntimeDefaults() {
+  if (isFileRuntime()) {
+    return { apiBase: FALLBACK_HTTP_BASE, wsBase: FALLBACK_WS_BASE };
+  }
+  const pathname = (window.location.pathname || "/").replace(/\/index\.html?$/i, "/");
+  const basePath = pathname.replace(/\/+$/, "") || "/";
+  const apiBase = `${window.location.origin}${basePath === "/" ? "" : basePath}`;
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+  const wsBase = `${wsProtocol}//${window.location.host}${basePath === "/" ? "" : basePath}`;
+  return { apiBase, wsBase };
+}
+
 const formRules: FormRules<RequestForm> = {
   baseUrl: [
     { required: true, message: "请输入 API 地址", trigger: "blur" },
-    { 
-      pattern: /^https?:\/\/.+/, 
-      message: "请输入有效的 HTTP/HTTPS 地址", 
-      trigger: "blur" 
+    {
+      pattern: /^(https?:\/\/.+|\/.+|\.\/.+)$/,
+      message: "请输入有效地址（http(s)://、/path 或 ./path）",
+      trigger: "blur",
     },
   ],
   wsBaseUrl: [
     { required: true, message: "请输入 WebSocket 地址", trigger: "blur" },
-    { 
-      pattern: /^wss?:\/\/.+/, 
-      message: "请输入有效的 WS/WSS 地址", 
-      trigger: "blur" 
+    {
+      pattern: /^(wss?:\/\/.+|https?:\/\/.+|\/.+|\.\/.+)$/,
+      message: "请输入有效地址（ws(s)://、http(s)://、/path 或 ./path）",
+      trigger: "blur",
     },
   ],
 };
 
 function loadSettings() {
-  formData.value.baseUrl = settingStore.baseUrl;
-  formData.value.wsBaseUrl = settingStore.wsBaseUrl;
+  const defaults = getRuntimeDefaults();
+  formData.value.baseUrl = (settingStore.baseUrl || defaults.apiBase).trim();
+  formData.value.wsBaseUrl = (settingStore.wsBaseUrl || defaults.wsBase).trim();
+
+  settingStore.baseUrl = formData.value.baseUrl;
+  settingStore.wsBaseUrl = formData.value.wsBaseUrl;
+}
+
+function normalizeHttpInput(value: string): string {
+  const normalized = value.trim();
+  if (!isFileRuntime()) return normalized;
+  if (normalized.startsWith("/")) {
+    return `${FALLBACK_HTTP_BASE.replace(/\/+$/, "")}${normalized}`;
+  }
+  if (normalized.startsWith("./")) {
+    return `${FALLBACK_HTTP_BASE.replace(/\/+$/, "")}/${normalized.slice(2)}`;
+  }
+  return normalized;
+}
+
+function normalizeWsInput(value: string): string {
+  const normalized = value.trim();
+  if (!isFileRuntime()) return normalized;
+  if (normalized.startsWith("/")) {
+    return `${FALLBACK_WS_BASE.replace(/\/+$/, "")}${normalized}`;
+  }
+  if (normalized.startsWith("./")) {
+    return `${FALLBACK_WS_BASE.replace(/\/+$/, "")}/${normalized.slice(2)}`;
+  }
+  return normalized;
 }
 
 function handleSubmit({ validateResult }: { validateResult: boolean }) {
   if (validateResult) {
-    settingStore.baseUrl = formData.value.baseUrl;
-    settingStore.wsBaseUrl = formData.value.wsBaseUrl;
+    const nextBaseUrl = normalizeHttpInput(formData.value.baseUrl);
+    const nextWsBaseUrl = normalizeWsInput(formData.value.wsBaseUrl);
+    formData.value.baseUrl = nextBaseUrl;
+    formData.value.wsBaseUrl = nextWsBaseUrl;
+    settingStore.baseUrl = nextBaseUrl;
+    settingStore.wsBaseUrl = nextWsBaseUrl;
     MessagePlugin.success("请求地址保存成功");
   }
 }
 
 function handleReset() {
-  formData.value.baseUrl = "http://localhost:60000";
-  formData.value.wsBaseUrl = "ws://localhost:60000";
+  const defaults = getRuntimeDefaults();
+  formData.value.baseUrl = defaults.apiBase;
+  formData.value.wsBaseUrl = defaults.wsBase;
   settingStore.baseUrl = formData.value.baseUrl;
   settingStore.wsBaseUrl = formData.value.wsBaseUrl;
-  MessagePlugin.success("已重置为默认地址");
+  MessagePlugin.success("已重置为当前站点地址");
 }
 
 onMounted(() => {


### PR DESCRIPTION
## 原有问题
- 前端默认把 API/WS 地址写死为 localhost，部署到域名或子路径后经常请求错误。

## 本次修改
- 将 `baseUrl/wsBaseUrl` 默认值改为空，启动时按运行环境自动推导默认地址。
- 新增运行时兜底逻辑：识别 file://、null origin、无 host 等场景并回退到可用地址。
- 保留 query 覆盖能力（`?baseUrl=...&wsBaseUrl=...`），并在路由变化时重新校正。
- WebSocket 客户端新增地址归一化：支持 ws(s)、http(s)、相对路径输入并自动转成可连接地址。
- 设置页校验规则升级，支持绝对地址与相对路径；file:// 场景提交时自动补全为可访问地址。
- 登录页与设置页提示文案更新为部署友好示例。

- 解决了「非 localhost 部署后前端连错地址」问题。
- 解决了「file:// 启动时 WS 地址异常」问题。
- 解决了「子路径部署必须手填完整地址」的问题。
- 减少了因旧配置残留导致的连接失败与重复配置成本。