### PR TITLE
添加对 Electron 运行时的支持，优化请求地址初始化逻辑，并在表单中禁用相关输入

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,27 +22,79 @@ const route = useRoute();
 const store = settingStore();
 const { baseUrl, wsBaseUrl } = storeToRefs(store);
 
+const initFromLocationSearch = (): boolean => {
+  const params = new URLSearchParams(window.location.search);
+  const nextBaseUrl = params.get("baseUrl");
+  const nextWsBaseUrl = params.get("wsBaseUrl");
+
+  let initialized = false;
+  if (nextBaseUrl) {
+    baseUrl.value = nextBaseUrl;
+    initialized = true;
+  }
+
+  if (nextWsBaseUrl) {
+    wsBaseUrl.value = nextWsBaseUrl;
+    initialized = true;
+  }
+
+  return initialized;
+};
+
+const initFromElectronRuntime = async (): Promise<boolean> => {
+  if (!window.electronRuntime) return false;
+
+  try {
+    const config = await window.electronRuntime.getBackendConfig();
+    if (config.baseUrl) {
+      baseUrl.value = config.baseUrl;
+    }
+    if (config.wsBaseUrl) {
+      wsBaseUrl.value = config.wsBaseUrl;
+    }
+    return Boolean(config.baseUrl || config.wsBaseUrl);
+  } catch (error) {
+    console.error("[Electron runtime 配置初始化失败]:", error);
+    return false;
+  }
+};
+
 // 从 URL query 参数设置请求地址
 const initFromQuery = () => {
   const query = route.query;
   // 支持通过 ?baseUrl=xxx 设置请求地址
   if (query.baseUrl && typeof query.baseUrl === "string") {
     baseUrl.value = query.baseUrl;
-    console.log('Set baseUrl to:', query.baseUrl);
+    console.log("Set baseUrl to:", query.baseUrl);
   }
   // 支持通过 ?wsBaseUrl=xxx 设置 WebSocket 地址
   if (query.wsBaseUrl && typeof query.wsBaseUrl === "string") {
     wsBaseUrl.value = query.wsBaseUrl;
-    console.log('Set wsBaseUrl to:', query.wsBaseUrl);
+    console.log("Set wsBaseUrl to:", query.wsBaseUrl);
   }
 };
-// 监听路由变化，确保 query 参数更新时也能处理
+
+const initRequestAddress = async () => {
+  const initializedBySearch = initFromLocationSearch();
+  const initializedByRuntime = await initFromElectronRuntime();
+
+  if (!initializedByRuntime && !initializedBySearch) {
+    initFromQuery();
+  }
+};
+
+// 优先使用 Electron 运行时注入，query 仅作为兜底兼容
+void initRequestAddress();
+
+// 非 Electron 模式下保留 query 动态更新能力
 watch(
   () => route.query,
   () => {
-    initFromQuery();
+    if (!window.electronRuntime) {
+      initFromQuery();
+    }
   },
-  { immediate: true, deep: true }
+  { deep: true }
 );
 // 初始化主题
 onMounted(() => {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -15,6 +15,17 @@ interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
 
+interface BackendRuntimeConfig {
+  baseUrl: string;
+  wsBaseUrl: string;
+}
+
+interface Window {
+  electronRuntime?: {
+    getBackendConfig: () => Promise<BackendRuntimeConfig>;
+  };
+}
+
 /**
  * 项目实体
  */

--- a/src/views/setting/components/requestConfig.vue
+++ b/src/views/setting/components/requestConfig.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="request-config">
+    <div v-if="isElectronRuntime" class="runtime-tip">
+      Electron 运行时地址由系统注入，当前为只读模式。
+    </div>
     <t-form :data="formData" labelAlign="top" :rules="formRules" @submit="handleSubmit">
       <t-form-item label="API 地址" name="baseUrl">
-        <t-input v-model="formData.baseUrl" placeholder="请输入 API 请求地址" clearable>
+        <t-input v-model="formData.baseUrl" :disabled="isElectronRuntime" placeholder="请输入 API 请求地址" clearable>
           <template #prefix-icon>
             <t-icon name="link" />
           </template>
         </t-input>
       </t-form-item>
       <t-form-item label="WebSocket地址" name="wsBaseUrl">
-        <t-input v-model="formData.wsBaseUrl" placeholder="请输入 WebSocket 地址" clearable>
+        <t-input v-model="formData.wsBaseUrl" :disabled="isElectronRuntime" placeholder="请输入 WebSocket 地址" clearable>
           <template #prefix-icon>
             <t-icon name="swap" />
           </template>
@@ -17,8 +20,8 @@
       </t-form-item>
       <t-form-item>
         <t-space size="small">
-          <t-button theme="primary" type="submit">保存</t-button>
-          <t-button theme="default" @click="handleReset">重置</t-button>
+          <t-button theme="primary" type="submit" :disabled="isElectronRuntime">保存</t-button>
+          <t-button theme="default" :disabled="isElectronRuntime" @click="handleReset">重置</t-button>
         </t-space>
       </t-form-item>
     </t-form>
@@ -26,7 +29,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, onMounted, computed } from "vue";
 import { MessagePlugin, type FormRules } from "tdesign-vue-next";
 import useSettingStore from "@/stores/setting";
 
@@ -36,6 +39,7 @@ interface RequestForm {
 }
 
 const settingStore = useSettingStore();
+const isElectronRuntime = computed(() => Boolean(window.electronRuntime));
 
 const formData = ref<RequestForm>({
   baseUrl: "",
@@ -67,6 +71,11 @@ function loadSettings() {
 }
 
 function handleSubmit({ validateResult }: { validateResult: boolean }) {
+  if (isElectronRuntime.value) {
+    MessagePlugin.warning("Electron 运行时地址已锁定");
+    return;
+  }
+
   if (validateResult) {
     settingStore.baseUrl = formData.value.baseUrl;
     settingStore.wsBaseUrl = formData.value.wsBaseUrl;
@@ -75,6 +84,11 @@ function handleSubmit({ validateResult }: { validateResult: boolean }) {
 }
 
 function handleReset() {
+  if (isElectronRuntime.value) {
+    MessagePlugin.warning("Electron 运行时地址已锁定");
+    return;
+  }
+
   formData.value.baseUrl = "http://localhost:60000";
   formData.value.wsBaseUrl = "ws://localhost:60000";
   settingStore.baseUrl = formData.value.baseUrl;
@@ -90,5 +104,15 @@ onMounted(() => {
 <style lang="scss" scoped>
 .request-config {
   padding: 10px 0;
+}
+
+.runtime-tip {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: #9a6700;
+  background: #fff8c5;
+  border: 1px solid #f0d885;
+  border-radius: 6px;
 }
 </style>


### PR DESCRIPTION
在主进程启用安全配置：contextIsolation: true、nodeIntegration: false，并通过 preload + ipc 暴露只读 getBackendConfig() 给前端。
启动策略改为：优先 60000，端口占用时自动回退随机端口；同时增强 startServe/closeServe 错误处理，避免 EADDRINUSE 和 ERR_SERVER_NOT_RUNNING 引发崩溃。
前端地址初始化顺序调整为：window.location.search -> electronRuntime -> route.query 兜底，解决随机端口场景仍打到 60000 的问题。
Electron 模式下锁定设置页 baseUrl/wsBaseUrl 输入与保存操作，防止运行时误改；非 Electron 模式保持原有可编辑行为。
打包侧增加 scripts/preload.js，并同步前端构建产物到 Toonflow-app/scripts/web，确保 dev:gui 实际运行到新逻辑。