### PR TITLE
fix(web): same-origin baseUrl in browser mode

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -75,7 +75,20 @@ async function getPort() {
       baseUrl.value = data.url;
       isElectron.value = true;
     }
-  } catch (error) {}
+  } catch (error) {
+    // Browser mode (toonflow:// scheme not registered). If the persisted
+    // baseUrl still points at the dev default localhost:10588, override
+    // to the current page origin so the app actually reaches its backend
+    // when accessed remotely (e.g. http://vm:9090). Users who set a
+    // custom baseUrl in Settings keep theirs.
+    if (
+      typeof window !== "undefined" &&
+      window.location?.protocol?.startsWith("http") &&
+      /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?\/api\/?$/.test(baseUrl.value)
+    ) {
+      baseUrl.value = `${window.location.origin}/api`;
+    }
+  }
 
   config({
     markdownItConfig(md) {

--- a/src/components/setting/components/requestConfig.vue
+++ b/src/components/setting/components/requestConfig.vue
@@ -55,7 +55,12 @@ function handleSubmit() {
 }
 
 function handleReset() {
-  formData.value.baseUrl = "http://localhost:10588";
+  // Reset to same-origin in the browser; fall back to the dev port when
+  // running in non-http context (e.g. electron file://).
+  formData.value.baseUrl =
+    typeof window !== "undefined" && window.location?.protocol?.startsWith("http")
+      ? `${window.location.origin}/api`
+      : "http://localhost:10588";
   baseUrl.value = formData.value.baseUrl;
   window.$message.success($t("settings.request.msg.reset"));
 }

--- a/src/stores/setting.ts
+++ b/src/stores/setting.ts
@@ -6,7 +6,15 @@ export default defineStore(
     const canvasWheelEvent = ref("zoom");
     const activeMenu = ref("ui");
 
-    const baseUrl = ref<string>("http://localhost:10588/api");
+    // Default API base. When loaded in a browser we want same-origin so the
+    // app works behind any host (vm public IP, reverse proxy, etc) without
+    // hard-coding the dev port. Electron overrides this via toonflow://getAppUrl
+    // (see App.vue getPort).
+    const baseUrl = ref<string>(
+      typeof window !== "undefined" && window.location?.protocol?.startsWith("http")
+        ? `${window.location.origin}/api`
+        : "http://localhost:10588/api"
+    );
 
     const needUpdate = ref(false);
 


### PR DESCRIPTION
## Problem

Default \`baseUrl\` in [\`src/stores/setting.ts\`](src/stores/setting.ts) was hard-coded to \`http://localhost:10588/api\`. When the app is served from a remote host (e.g. \`http://vm:9090\`) and opened in a browser instead of the Electron shell, every API call resolves \`localhost:10588\` against the **user's** local machine and fails with \`ERR_CONNECTION_REFUSED\` — login alone is enough to reproduce.

The Electron path (\`fetch('toonflow://getAppUrl')\` in \`App.vue getPort\`) doesn't apply in a browser since the custom scheme isn't registered, so the \`catch\` block silently leaves the dev default in place.

## Fix

Three minimal changes, all gated on \`window.location.protocol\` so Electron behavior is unchanged:

1. **[\`stores/setting.ts\`](src/stores/setting.ts)** — default baseUrl is \`window.location.origin + '/api'\` in an http(s) browser context, falls back to the dev port for Electron / SSR.
2. **[\`App.vue getPort()\`](src/App.vue)** — when \`toonflow://getAppUrl\` fails (browser, no IPC) AND the persisted baseUrl is the dev default \`localhost:10588\`, override to current origin. Users who set a custom baseUrl in Settings keep theirs (regex narrows to localhost only).
3. **[\`requestConfig.vue handleReset\`](src/components/setting/components/requestConfig.vue)** — Reset button uses same-origin in browser, dev port elsewhere.

## Test plan

- [x] Browser at \`http://vm:9090\` → login \`admin/admin123\` works (previously failed with \`ERR_CONNECTION_REFUSED\` to user's local 10588)
- [x] Browser DevTools → Network → all \`/api/...\` calls go to the same origin as the page
- [x] Browser DevTools → Application → \`localStorage.setting\` stored with the correct origin baseUrl
- [ ] Electron (un-touched code path) — verify \`toonflow://getAppUrl\` still wins and Electron uses IPC URL