### PR TITLE
feat: add manual Jimeng video workflow

### DIFF
--- a/src/components/imageTools.vue
+++ b/src/components/imageTools.vue
@@ -48,7 +48,7 @@ const props = withDefaults(
 const placement = computed<any>(() => props.placement);
 
 const bigSrc = computed(() => {
-  return `${props.src.split("?") ?   props.src.split("?")[0] : props.src}`;
+  return props.src.split("?")[0] || props.src;
 });
 
 const positionStyle = computed<any>(() => {
@@ -111,7 +111,12 @@ async function handleCopy() {
     await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
     window.$message.success($t("components.imageTools.msg.copied"));
   } catch {
-    window.$message.error($t("components.imageTools.msg.copyFailed"));
+    try {
+      await navigator.clipboard.writeText(props.src);
+      window.$message.warning("图片复制受限，已复制图片链接");
+    } catch {
+      window.$message.error($t("components.imageTools.msg.copyFailed"));
+    }
   }
 }
 

--- a/src/utils/manualVideoModes.test.ts
+++ b/src/utils/manualVideoModes.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+  MANUAL_OMNI_REFERENCE_MODE,
+  MANUAL_SMART_MULTI_FRAME_MODE,
+  appendManualVideoModeOptions,
+  buildSmartFrameTransitionText,
+  getPromptGenerationMode,
+  isManualOmniReferenceMode,
+  isManualSmartMultiFrameMode,
+  isManualVideoMode,
+} from "./manualVideoModes";
+
+const baseOptions = [
+  { value: "text", label: "文本生视频" },
+  { value: "singleImage", label: "单图" },
+];
+
+assert.equal(isManualVideoMode(MANUAL_OMNI_REFERENCE_MODE), true);
+assert.equal(isManualVideoMode(MANUAL_SMART_MULTI_FRAME_MODE), true);
+assert.equal(isManualVideoMode("text"), false);
+assert.equal(isManualOmniReferenceMode(MANUAL_OMNI_REFERENCE_MODE), true);
+assert.equal(isManualSmartMultiFrameMode(MANUAL_SMART_MULTI_FRAME_MODE), true);
+
+assert.deepEqual(getPromptGenerationMode(MANUAL_OMNI_REFERENCE_MODE), ["imageReference:9", "videoReference:3", "audioReference:3"]);
+assert.deepEqual(getPromptGenerationMode(MANUAL_SMART_MULTI_FRAME_MODE), ["imageReference:9"]);
+assert.equal(getPromptGenerationMode("singleImage"), "singleImage");
+
+assert.deepEqual(
+  appendManualVideoModeOptions(baseOptions, "jimeng-seedance-pro").map((item) => item.value),
+  ["text", "singleImage", MANUAL_OMNI_REFERENCE_MODE, MANUAL_SMART_MULTI_FRAME_MODE],
+);
+assert.deepEqual(
+  appendManualVideoModeOptions(baseOptions, "other-model").map((item) => item.value),
+  ["text", "singleImage"],
+);
+assert.deepEqual(
+  appendManualVideoModeOptions([{ value: MANUAL_OMNI_REFERENCE_MODE, label: "已存在" }], "jimeng").map((item) => item.value),
+  [MANUAL_OMNI_REFERENCE_MODE, MANUAL_SMART_MULTI_FRAME_MODE],
+);
+
+assert.equal(buildSmartFrameTransitionText(0), "第 1 帧到第 2 帧：保持主体一致，镜头自然过渡，动作连续，画面风格和光影统一。");
+
+console.log("manualVideoModes tests passed");

--- a/src/utils/manualVideoModes.ts
+++ b/src/utils/manualVideoModes.ts
@@ -1,0 +1,47 @@
+export const MANUAL_OMNI_REFERENCE_MODE = "jimengOmniReferenceManual";
+export const MANUAL_SMART_MULTI_FRAME_MODE = "jimengSmartMultiFrameManual";
+
+export type ManualVideoMode = typeof MANUAL_OMNI_REFERENCE_MODE | typeof MANUAL_SMART_MULTI_FRAME_MODE;
+export type VideoModeOption = { value: string; label: string };
+
+const OMNI_REFERENCE_PROMPT_MODE = ["imageReference:9", "videoReference:3", "audioReference:3"] as const;
+const SMART_MULTI_FRAME_PROMPT_MODE = ["imageReference:9"] as const;
+
+export function isManualOmniReferenceMode(mode: unknown): mode is typeof MANUAL_OMNI_REFERENCE_MODE {
+  return mode === MANUAL_OMNI_REFERENCE_MODE;
+}
+
+export function isManualSmartMultiFrameMode(mode: unknown): mode is typeof MANUAL_SMART_MULTI_FRAME_MODE {
+  return mode === MANUAL_SMART_MULTI_FRAME_MODE;
+}
+
+export function isManualVideoMode(mode: unknown): mode is ManualVideoMode {
+  return isManualOmniReferenceMode(mode) || isManualSmartMultiFrameMode(mode);
+}
+
+export function isJimengOrSeedanceModel(model?: string | null): boolean {
+  return /jimeng|即梦|seedance/i.test(String(model ?? ""));
+}
+
+export function appendManualVideoModeOptions<T extends VideoModeOption>(options: T[], model?: string | null): VideoModeOption[] {
+  if (!isJimengOrSeedanceModel(model)) return options;
+  const next: VideoModeOption[] = [...options];
+  if (!next.some((item) => item.value === MANUAL_OMNI_REFERENCE_MODE)) {
+    next.push({ value: MANUAL_OMNI_REFERENCE_MODE, label: "全能参考（官网手动）" });
+  }
+  if (!next.some((item) => item.value === MANUAL_SMART_MULTI_FRAME_MODE)) {
+    next.push({ value: MANUAL_SMART_MULTI_FRAME_MODE, label: "智能多帧（官网手动）" });
+  }
+  return next;
+}
+
+export function getPromptGenerationMode<T>(mode: T): T | string[] {
+  if (isManualOmniReferenceMode(mode)) return [...OMNI_REFERENCE_PROMPT_MODE];
+  if (isManualSmartMultiFrameMode(mode)) return [...SMART_MULTI_FRAME_PROMPT_MODE];
+  return mode;
+}
+
+export function buildSmartFrameTransitionText(index: number): string {
+  const from = Math.max(0, index) + 1;
+  return `第 ${from} 帧到第 ${from + 1} 帧：保持主体一致，镜头自然过渡，动作连续，画面风格和光影统一。`;
+}

--- a/src/views/production/components/workbench/generate/components/imageSelect.vue
+++ b/src/views/production/components/workbench/generate/components/imageSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="imageUploadBox ac">
     <!-- 单图模式 -->
-    <template v-if="mode == 'singleImage' || Array.isArray(parseMode(mode as string))">
+    <template v-if="mode == 'singleImage' || Array.isArray(parseMode(mode as string)) || isManualReferenceMode">
       <div class="uploadBtn c fc" v-for="(item, index) in mode == 'singleImage' ? imageList.slice(0, 1) : imageList" :key="index">
         <template v-if="item.src">
           <t-image v-if="item.fileType == 'image'" :src="item.src" fit="contain" class="uploadPreview">
@@ -115,6 +115,7 @@ import { ref } from "vue";
 import "@/views/production/components/workbench/type/type";
 import assetsCheck, { type AssetType, type ClipMediaType } from "@/utils/assetsCheck";
 import axios from "@/utils/axios";
+import { isManualOmniReferenceMode, isManualSmartMultiFrameMode } from "@/utils/manualVideoModes";
 
 const props = defineProps<{
   mode: VideoMode;
@@ -125,6 +126,7 @@ const imageList = defineModel<UploadItem[]>({
 });
 //分镜选择弹窗
 const storyboardDialogVisible = ref(false);
+const isManualReferenceMode = computed(() => isManualOmniReferenceMode(props.mode) || isManualSmartMultiFrameMode(props.mode));
 
 /** 空占位项，用于首尾帧模式中未设置的槽位 */
 const EMPTY_SLOT: UploadItem = { fileType: "image", id: null, src: "" } as any;
@@ -190,16 +192,21 @@ function getFileTypeByExt(src: string | undefined): "image" | "video" | "audio" 
 }
 /** 根据混合模式推导当前允许的 clip 媒体类型 */
 const mixedClipMediaTypes = computed<ClipMediaType[]>(() => {
-  const mode = props.mode;
+  const mode = parseMode(props.mode as string);
+  if (isManualSmartMultiFrameMode(props.mode)) return ["image"];
+  if (isManualOmniReferenceMode(props.mode)) return ["image", "video", "audio"];
   if (!Array.isArray(mode)) return [];
   const map: Record<string, ClipMediaType> = { audioReference: "audio", imageReference: "image", videoReference: "video" };
-  return mode.filter((m) => m in map).map((m) => map[m]);
+  return mode
+    .map((m) => String(m).split(":")[0])
+    .filter((m) => m in map)
+    .map((m) => map[m]);
 });
 let currentSlot: "start" | "end" | "" = "";
 function handleMixedAdd(slot: "start" | "end" | "" = "") {
   if (!props.mode) return window.$message.error($t("workbench.generate.notSelectMode"));
   currentSlot = slot;
-  const multiple = Array.isArray(parseMode(props.mode as string));
+  const multiple = Array.isArray(parseMode(props.mode as string)) || isManualReferenceMode.value;
   const dlg = DialogPlugin.confirm({
     header: $t("workbench.generate.selectSource"),
     confirmBtn: $t("workbench.generate.confirm"),

--- a/src/views/production/components/workbench/generate/components/track.vue
+++ b/src/views/production/components/workbench/generate/components/track.vue
@@ -75,6 +75,7 @@ import projectStore from "@/stores/project";
 import imageListCacheStore from "@/stores/imageListCache";
 import JSZip from "jszip";
 import settingStore from "@/stores/setting";
+import { getPromptGenerationMode, isManualVideoMode } from "@/utils/manualVideoModes";
 
 const { otherSetting } = storeToRefs(settingStore());
 const { project } = storeToRefs(projectStore());
@@ -264,7 +265,7 @@ function batchGenText() {
       projectId: project.value?.id,
       trackData,
       model: props.modelParmas.model,
-      mode: props.modelParmas.mode,
+      mode: getPromptGenerationMode(props.modelParmas.mode),
       concurrentCount: otherSetting.value.assetsBatchGenereateSize,
     })
     .then(({ data }) => {
@@ -302,6 +303,10 @@ function getTrackUploadInfo(track: TrackItem, filterEmpty = false) {
 const generateVideoLoad = ref(false);
 /** 批量为已勾选轨道生成视频 */
 function batchGenVideo() {
+  if (isManualVideoMode(props.modelParmas.mode)) {
+    window.$message.info("手动官网模式不支持批量自动生成，请逐条复制提示词并上传官网生成结果。");
+    return;
+  }
   const dlg = DialogPlugin.confirm({
     header: $t("workbench.generate.generateConfirm"),
     body: $t("workbench.generate.generateVideosInBatches"),

--- a/src/views/production/components/workbench/generate/components/video.vue
+++ b/src/views/production/components/workbench/generate/components/video.vue
@@ -1,7 +1,14 @@
 <template>
   <t-card :title="'#' + (activeTrackIndex + 1) + $t('workbench.generate.videoMenu')" header-bordered style="height: 100%">
     <template #actions>
-      <t-button size="small" :loading="generating" @click="emit('generate')">{{ $t("workbench.generate.generate") }}</t-button>
+      <div class="cardActions f ac">
+        <t-button size="small" variant="outline" :loading="uploadingVideo" @click="uploadVideo">
+          <template #icon><i-upload-one size="14" /></template>
+          上传视频
+        </t-button>
+        <t-button v-if="manualMode" size="small" @click="emit('copyPrompt')">复制提示词</t-button>
+        <t-button v-else size="small" :loading="generating" @click="emit('generate')">{{ $t("workbench.generate.generate") }}</t-button>
+      </div>
     </template>
     <div class="history">
       <div class="titleBox f ac">
@@ -79,12 +86,14 @@
 
 <script setup lang="ts">
 import type { Ref } from "vue";
+import { useFileDialog } from "@vueuse/core";
 import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
 
 const props = defineProps<{
   activeTrackIndex: number;
   generating?: boolean;
+  manualMode?: boolean;
 }>();
 const currentTrack = defineModel<TrackItem>("currentTrack", {
   default: () => {},
@@ -92,6 +101,7 @@ const currentTrack = defineModel<TrackItem>("currentTrack", {
 const emit = defineEmits<{
   generate: [];
   refresh: [];
+  copyPrompt: [];
 }>();
 
 const { project } = storeToRefs(projectStore());
@@ -101,6 +111,72 @@ const selectVideoId = ref();
 const videoCoverMap = ref<Record<string, string>>({});
 const videoPlayerVisible = ref(false);
 const playingVideoSrc = ref<string>();
+const uploadingVideo = ref(false);
+const { open: openVideoFileDialog, onChange: onVideoFileChange } = useFileDialog({
+  multiple: false,
+  reset: true,
+  accept: ".mp4,.webm,.mov,.avi,.mkv",
+});
+
+function readVideoFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(file);
+  });
+}
+
+function isVideoFile(file: File): boolean {
+  return file.type.startsWith("video/") || /\.(mp4|webm|mov|avi|mkv)$/i.test(file.name);
+}
+
+function normalizeUploadedVideo(data: any): VideoItem {
+  const item = data?.video ?? data;
+  return {
+    id: item.id,
+    src: item.src ?? item.filePath ?? item.url ?? "",
+    state: (item.state ?? "已完成") as VideoItem["state"],
+    errorReason: item.errorReason ?? null,
+    duration: item.duration ?? null,
+  };
+}
+
+function uploadVideo() {
+  if (!currentTrack.value?.id) {
+    window.$message.error("请先选择轨道");
+    return;
+  }
+  openVideoFileDialog();
+}
+
+onVideoFileChange(async (files) => {
+  if (!files?.length) return;
+  if (!currentTrack.value?.id) return;
+  const file = files[0];
+  if (!isVideoFile(file)) {
+    window.$message.error("仅支持上传 .mp4/.webm/.mov/.avi/.mkv 视频文件");
+    return;
+  }
+  uploadingVideo.value = true;
+  try {
+    const base64Data = await readVideoFileAsDataUrl(file);
+    const { data } = await axios.post("/production/workbench/uploadVideo", {
+      projectId: project.value?.id,
+      scriptId: episodesId.value,
+      trackId: currentTrack.value.id,
+      name: file.name,
+      base64Data,
+    });
+    currentTrack.value.videoList.unshift(normalizeUploadedVideo(data));
+    window.$message.success("视频已上传");
+    emit("refresh");
+  } catch (e) {
+    window.$message.error((e as any)?.message ?? "视频上传失败");
+  } finally {
+    uploadingVideo.value = false;
+  }
+});
 
 /** 选中历史视频并同步到后端 */
 async function selectVideo(v: HistoryVideoItem) {
@@ -337,6 +413,9 @@ function previewVideo(v: HistoryVideoItem) {
       }
     }
   }
+}
+.cardActions {
+  gap: 8px;
 }
 
 .videoPlayerBox {

--- a/src/views/production/components/workbench/generate/index.vue
+++ b/src/views/production/components/workbench/generate/index.vue
@@ -22,13 +22,46 @@
             </div>
           </div>
         </t-card>
+        <div class="manualAssist" v-if="isManualMode">
+          <div class="manualHeader f ac jb">
+            <span class="manualTitle">{{ manualModeTitle }}</span>
+            <t-button size="small" variant="outline" @click="copyCurrentPrompt">复制提示词</t-button>
+          </div>
+          <div class="manualHint">
+            {{
+              isSmartManualMode
+                ? "按当前顺序复制帧图到即梦智能多帧，逐段复制帧间过渡提示词。"
+                : "复制或下载参考素材到即梦全能参考，官网生成后上传视频回填当前轨道。"
+            }}
+          </div>
+          <div class="frameWorkspace" v-if="isSmartManualMode">
+            <div class="frameItem" v-for="(frame, index) in smartFrameItems" :key="`${frame.sources}-${frame.id}-${index}`">
+              <div class="frameThumb">
+                <img v-if="frame.src" :src="frame.src" />
+                <span v-else>无图</span>
+              </div>
+              <div class="frameMeta f ac jb">
+                <span>第 {{ index + 1 }} 帧</span>
+                <small>{{ getFrameSourceLabel(frame, index) }}</small>
+              </div>
+              <t-button size="small" variant="text" block @click="copyFrameImage(frame)">复制帧图</t-button>
+              <template v-if="index < smartFrameItems.length - 1">
+                <div class="transitionText">{{ buildSmartFrameTransitionText(index) }}</div>
+                <t-button size="small" variant="text" block @click="copyText(buildSmartFrameTransitionText(index))">复制过渡提示词</t-button>
+              </template>
+            </div>
+            <div class="emptyFrameHint" v-if="smartFrameItems.length < 2">智能多帧建议至少选择 2 张图片帧。</div>
+          </div>
+        </div>
       </div>
       <div class="video">
         <videoCard
           v-if="currentTrack"
           :active-track-index="activeTrackIndex"
+          :manual-mode="isManualMode"
           v-model:current-track="currentTrack"
           @refresh="getGenerateData"
+          @copyPrompt="copyCurrentPrompt"
           @generate="generateVideo" />
       </div>
     </div>
@@ -56,6 +89,16 @@ import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
 import promptEditor from "@/components/promptEditor.vue";
 import imageListCacheStore from "@/stores/imageListCache";
+import {
+  appendManualVideoModeOptions,
+  buildSmartFrameTransitionText,
+  getPromptGenerationMode,
+  isJimengOrSeedanceModel,
+  isManualSmartMultiFrameMode,
+  isManualVideoMode,
+  MANUAL_OMNI_REFERENCE_MODE,
+  MANUAL_SMART_MULTI_FRAME_MODE,
+} from "@/utils/manualVideoModes";
 
 const { project } = storeToRefs(projectStore());
 const episodesId = inject<Ref<number>>("episodesId")!;
@@ -104,12 +147,14 @@ const imageList = computed({
       const cached = getCache(pid, sid, trackId);
 
       if (cached?.length) {
-        return [...cached].sort((a, b) => getImageItemPriority(a) - getImageItemPriority(b));
+        const list = [...cached];
+        return isSmartManualMode.value ? list : list.sort((a, b) => getImageItemPriority(a) - getImageItemPriority(b));
       }
     }
     const medias = currentTrack.value?.medias;
     if (!medias?.length) return [];
-    return [...(medias as UploadItem[])].sort((a, b) => getImageItemPriority(a) - getImageItemPriority(b));
+    const list = [...(medias as UploadItem[])];
+    return isSmartManualMode.value ? list : list.sort((a, b) => getImageItemPriority(a) - getImageItemPriority(b));
   },
   set(val: UploadItem[]) {
     if (currentTrack.value) {
@@ -164,14 +209,24 @@ const modeList = computed(() => {
     }
     return modeLabelMap[m] || m;
   }
-  return modeOptions.value.mode
+  const options = modeOptions.value.mode
     ? modeOptions.value.mode.map((mode) =>
         Array.isArray(mode)
           ? { value: JSON.stringify(mode), label: mode.map((m) => parseRefLabel(m)).join(" + ") + "参考" }
           : { value: mode, label: modeLabelMap[mode] || mode },
       )
     : [];
+  return appendManualVideoModeOptions(options, manualModeModelKey.value);
 });
+const manualModeModelKey = computed(() => `${modelParmas.value.model} ${modeOptions.value.name} ${modeOptions.value.modelName}`);
+const isManualMode = computed(() => isManualVideoMode(modelParmas.value.mode));
+const isSmartManualMode = computed(() => isManualSmartMultiFrameMode(modelParmas.value.mode));
+const manualModeTitle = computed(() => {
+  if (modelParmas.value.mode === MANUAL_SMART_MULTI_FRAME_MODE) return "即梦智能多帧官网辅助";
+  if (modelParmas.value.mode === MANUAL_OMNI_REFERENCE_MODE) return "即梦全能参考官网辅助";
+  return "即梦官网辅助";
+});
+const smartFrameItems = computed(() => imageList.value.filter((item) => item.fileType === "image" && item.src));
 const currentTrack = computed({
   get() {
     return trackList.value[activeTrackIndex.value];
@@ -216,13 +271,14 @@ watch(
 
       const currentParsed = parseMode(modelParmas.value.mode);
       const modeMatched =
-        currentParsed !== null &&
-        data.mode.some((m: VideoMode) => {
-          if (Array.isArray(m) && Array.isArray(currentParsed)) {
-            return JSON.stringify(m) === JSON.stringify(currentParsed);
-          }
-          return m == currentParsed;
-        });
+        (isManualVideoMode(currentParsed) && isJimengOrSeedanceModel(`${val} ${data.name} ${data.modelName}`)) ||
+        (currentParsed !== null &&
+          data.mode.some((m: VideoMode) => {
+            if (Array.isArray(m) && Array.isArray(currentParsed)) {
+              return JSON.stringify(m) === JSON.stringify(currentParsed);
+            }
+            return m == currentParsed;
+          }));
       if (!modeMatched) {
         const newMode = Array.isArray(data.mode[0]) ? JSON.stringify(data.mode[0]) : data.mode[0];
         modeChange(newMode);
@@ -325,7 +381,7 @@ async function genText() {
       trackId: currentTrackId,
       info: info,
       model: modelParmas.value.model,
-      mode: modelParmas.value.mode,
+      mode: getPromptGenerationMode(modelParmas.value.mode),
     });
     track.prompt = data;
     track.state = "已完成";
@@ -333,6 +389,39 @@ async function genText() {
     track.state = "生成失败";
     window.$message.error((e as Error)?.message ?? "提示词生成失败");
   }
+}
+async function copyText(text: string) {
+  if (!text) return window.$message.warning("没有可复制内容");
+  try {
+    await navigator.clipboard.writeText(text);
+    window.$message.success("已复制");
+  } catch {
+    window.$message.error("复制失败");
+  }
+}
+function copyCurrentPrompt() {
+  return copyText(currentTrack.value?.prompt ?? "");
+}
+async function copyFrameImage(item: UploadItem) {
+  if (!item.src) return window.$message.warning("没有可复制图片");
+  try {
+    const response = await fetch(item.src);
+    const blob = await response.blob();
+    if (!navigator.clipboard?.write || typeof ClipboardItem === "undefined") throw new Error("clipboard image unsupported");
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type || "image/png"]: blob })]);
+    window.$message.success("已复制图片");
+  } catch {
+    try {
+      await navigator.clipboard.writeText(item.src);
+      window.$message.warning("图片复制受限，已复制图片链接");
+    } catch {
+      window.$message.error("复制失败");
+    }
+  }
+}
+function getFrameSourceLabel(item: UploadItem, index: number) {
+  if (item.sources === "storyboard") return `分镜 P${(item.index ?? index) + 1}`;
+  return "资产参考";
 }
 function trackChange(prevIndex?: number) {
   // 切换前：将旧轨道的 imageList 保存到缓存
@@ -385,6 +474,11 @@ onMounted(() => {
 });
 /** 单个轨道生成视频 */
 async function generateVideo() {
+  if (isManualMode.value) {
+    window.$message.info("手动官网模式不会调用自动生成，请复制提示词到即梦官网生成后再上传结果。");
+    copyCurrentPrompt();
+    return;
+  }
   const dlg = DialogPlugin.confirm({
     header: $t("workbench.generate.generateConfirm"),
     body: $t("workbench.generate.generateConfirmBody"),
@@ -554,9 +648,13 @@ onUnmounted(() => {
       width: 50%;
       height: 100%;
       min-height: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
       .videoPrompt {
         width: 100%;
-        height: 100%;
+        flex: 1;
+        min-height: 0;
         overflow: hidden;
         display: flex;
         flex-direction: column;
@@ -578,6 +676,79 @@ onUnmounted(() => {
             min-height: 0;
             overflow-y: auto;
           }
+        }
+      }
+      .manualAssist {
+        flex-shrink: 0;
+        padding: 10px;
+        border: 1px solid var(--td-component-border);
+        border-radius: 8px;
+        background: var(--td-bg-color-container);
+        .manualHeader {
+          gap: 8px;
+          margin-bottom: 6px;
+        }
+        .manualTitle {
+          font-size: 13px;
+          font-weight: 600;
+          color: var(--td-text-color-primary);
+        }
+        .manualHint,
+        .emptyFrameHint {
+          font-size: 12px;
+          line-height: 1.5;
+          color: var(--td-text-color-secondary);
+        }
+        .frameWorkspace {
+          margin-top: 8px;
+          display: flex;
+          gap: 8px;
+          overflow-x: auto;
+          padding-bottom: 4px;
+        }
+        .frameItem {
+          width: 178px;
+          flex-shrink: 0;
+          border: 1px solid var(--td-component-border);
+          border-radius: 8px;
+          padding: 6px;
+          background: var(--td-bg-color-secondarycontainer);
+        }
+        .frameThumb {
+          width: 100%;
+          aspect-ratio: 16 / 9;
+          border-radius: 6px;
+          overflow: hidden;
+          background: var(--td-bg-color-container);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: var(--td-text-color-placeholder);
+          img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+          }
+        }
+        .frameMeta {
+          margin-top: 6px;
+          gap: 6px;
+          font-size: 12px;
+          small {
+            color: var(--td-text-color-secondary);
+            white-space: nowrap;
+          }
+        }
+        .transitionText {
+          margin-top: 6px;
+          min-height: 36px;
+          font-size: 12px;
+          line-height: 1.45;
+          color: var(--td-text-color-secondary);
+        }
+        .emptyFrameHint {
+          align-self: center;
+          white-space: nowrap;
         }
       }
     }

--- a/src/views/production/components/workbench/type/type.ts
+++ b/src/views/production/components/workbench/type/type.ts
@@ -1,6 +1,8 @@
-type ReferenceType = "videoReference" | "imageReference" | "audioReference" | "textReference";
+type ReferenceTypeBase = "videoReference" | "imageReference" | "audioReference" | "textReference";
+type ReferenceType = ReferenceTypeBase | `${ReferenceTypeBase}:${number}`;
 type Type = "imageReference" | "startImage" | "endImage" | "videoReference" | "audioReference";
-type VideoMode = "singleImage" | "startEndRequired" | "endFrameOptional" | "startFrameOptional" | "text" | ReferenceType[];
+type ManualVideoMode = "jimengOmniReferenceManual" | "jimengSmartMultiFrameManual";
+type VideoMode = "singleImage" | "startEndRequired" | "endFrameOptional" | "startFrameOptional" | "text" | ManualVideoMode | ReferenceType[];
 
 interface UploadItemBase {
   fileType: "image" | "video" | "audio";
@@ -60,6 +62,7 @@ interface VideoItem {
   src: string;
   state: "未生成" | "生成中" | "已完成" | "生成失败";
   errorReason?: string | null;
+  duration?: number | string | null;
 }
 interface TrackMediaBase {
   src: string;


### PR DESCRIPTION
视频模式下拉新增 全能参考（官网手动）、智能多帧（官网手动）
只对 Jimeng/Seedance 相关模型注入
新增 src/utils/manualVideoModes.ts
提示词生成时手动 mode 映射成后端兼容多参考 mode
手动模式点击主按钮只复制提示词，不调用 /generateVideo
批量视频生成在手动模式下拦截
批量提示词继续走 /batchGeneratePrompt
智能多帧增加“帧序工作区”，保留素材选择顺序
每帧可复制帧图，每两帧之间可复制过渡提示词
复用并增强 ImageTools，复制图片失败时降级复制链接
视频卡片新增上传视频，调用 /production/workbench/uploadVideo 回填当前轨道 videoList