### PR TITLE
feat(cornerScape): add reference image upload UI

### DIFF
--- a/src/locales/language/en.json
+++ b/src/locales/language/en.json
@@ -894,7 +894,10 @@
         "replaceSuccess": "Replacement successful",
         "promptGenFail": "Prompt word generation failed",
         "saveSuccess": "Modification of prompt word successful",
-        "saveFailed": "Prompt word modification failed"
+        "saveFailed": "Prompt word modification failed",
+        "imageTooLarge": "Image size cannot exceed 10MB",
+        "uploadSuccess": "Upload successful",
+        "uploadFailed": "Upload failed"
       },
       "history": "historical pictures",
       "confirmReplace": "Confirm replacement",
@@ -907,7 +910,12 @@
       "cancelGeneration": "Cancel generation",
       "selectGenerating": "Select the item being generated",
       "noGenerating": "No data being generated",
-      "checkNumber": "Select quantity"
+      "checkNumber": "Select quantity",
+      "assetsReferenceImageLabel": "Reference Images",
+      "uploadReferenceImage": "Upload Reference Image",
+      "referenceImageHint": "Local images + history images will be used as references for regeneration",
+      "noReferenceImage": "No reference images attached",
+      "useAsReference": "Set as Reference"
     },
     "script": {
       "searchPlaceholder": "Search script names...",

--- a/src/locales/language/ja_JP.json
+++ b/src/locales/language/ja_JP.json
@@ -756,7 +756,10 @@
         "replaceSuccess": "交換に成功しました",
         "promptGenFail": "プロンプト単語の生成に失敗しました",
         "saveSuccess": "プロンプトワードの変更が成功しました",
-        "saveFailed": "プロンプトワードの変更に失敗しました"
+        "saveFailed": "プロンプトワードの変更に失敗しました",
+        "imageTooLarge": "画像サイズは10MB以下にしてください",
+        "uploadSuccess": "アップロード成功",
+        "uploadFailed": "アップロード失敗"
       },
       "history": "歴史的な写真",
       "confirmReplace": "交換の確認",
@@ -769,7 +772,12 @@
       "cancelGeneration": "生成をキャンセルする",
       "selectGenerating": "生成されるアイテムを選択します",
       "noGenerating": "データは生成されていません",
-      "checkNumber": "数量を選択してください"
+      "checkNumber": "数量を選択してください",
+      "assetsReferenceImageLabel": "参考画像",
+      "uploadReferenceImage": "参考画像をアップロード",
+      "referenceImageHint": "ローカル画像と履歴画像が再生成の参考になります",
+      "noReferenceImage": "参考画像が未設定です",
+      "useAsReference": "参考として設定"
     },
     "script": {
       "searchPlaceholder": "シナリオ名を検索...",

--- a/src/locales/language/ru_RU.json
+++ b/src/locales/language/ru_RU.json
@@ -756,7 +756,10 @@
         "replaceSuccess": "Замена прошла успешно",
         "promptGenFail": "Не удалось создать быстрое слово.",
         "saveSuccess": "Изменение слова подсказки успешно выполнено",
-        "saveFailed": "Изменение слова подсказки не удалось"
+        "saveFailed": "Изменение слова подсказки не удалось",
+        "imageTooLarge": "Image size cannot exceed 10MB",
+        "uploadSuccess": "Upload successful",
+        "uploadFailed": "Upload failed"
       },
       "history": "исторические фотографии",
       "confirmReplace": "Подтвердить замену",
@@ -769,7 +772,12 @@
       "cancelGeneration": "Отменить генерацию",
       "selectGenerating": "Выберите создаваемый элемент",
       "noGenerating": "Данные не генерируются",
-      "checkNumber": "Выберите количество"
+      "checkNumber": "Выберите количество",
+      "assetsReferenceImageLabel": "Reference Images",
+      "uploadReferenceImage": "Upload Reference Image",
+      "referenceImageHint": "Local images + history images will be used as references for regeneration",
+      "noReferenceImage": "No reference images attached",
+      "useAsReference": "Set as Reference"
     },
     "script": {
       "searchPlaceholder": "Поиск по названию сценария...",

--- a/src/locales/language/th_TH.json
+++ b/src/locales/language/th_TH.json
@@ -757,7 +757,10 @@
         "replaceSuccess": "การเปลี่ยนสำเร็จ",
         "promptGenFail": "การสร้างคำพร้อมท์ล้มเหลว",
         "saveSuccess": "การแก้ไขคำพร้อมท์สำเร็จ",
-        "saveFailed": "การแก้ไขคำพร้อมท์ล้มเหลว"
+        "saveFailed": "การแก้ไขคำพร้อมท์ล้มเหลว",
+        "imageTooLarge": "Image size cannot exceed 10MB",
+        "uploadSuccess": "Upload successful",
+        "uploadFailed": "Upload failed"
       },
       "history": "ภาพประวัติศาสตร์",
       "confirmReplace": "ยืนยันการเปลี่ยน",
@@ -770,7 +773,12 @@
       "cancelGeneration": "ยกเลิกการสร้าง",
       "selectGenerating": "เลือกรายการที่กำลังสร้าง",
       "noGenerating": "ไม่มีการสร้างข้อมูล",
-      "checkNumber": "เลือกปริมาณ"
+      "checkNumber": "เลือกปริมาณ",
+      "assetsReferenceImageLabel": "Reference Images",
+      "uploadReferenceImage": "Upload Reference Image",
+      "referenceImageHint": "Local images + history images will be used as references for regeneration",
+      "noReferenceImage": "No reference images attached",
+      "useAsReference": "Set as Reference"
     },
     "script": {
       "searchPlaceholder": "ค้นหาชื่อบทภาพยนตร์...",

--- a/src/locales/language/vi-VN.json
+++ b/src/locales/language/vi-VN.json
@@ -747,7 +747,10 @@
         "replaceSuccess": "Thay thế thành công",
         "promptGenFail": "Tạo từ nhắc nhở không thành công",
         "saveSuccess": "Sửa đổi lời nhắc thành công",
-        "saveFailed": "Sửa đổi từ nhắc nhở không thành công"
+        "saveFailed": "Sửa đổi từ nhắc nhở không thành công",
+        "imageTooLarge": "Image size cannot exceed 10MB",
+        "uploadSuccess": "Upload successful",
+        "uploadFailed": "Upload failed"
       },
       "history": "hình ảnh lịch sử",
       "confirmReplace": "Xác nhận thay thế",
@@ -760,7 +763,12 @@
       "cancelGeneration": "Hủy tạo",
       "selectGenerating": "Chọn mục đang được tạo",
       "noGenerating": "Không có dữ liệu nào được tạo",
-      "checkNumber": "Chọn số lượng"
+      "checkNumber": "Chọn số lượng",
+      "assetsReferenceImageLabel": "Reference Images",
+      "uploadReferenceImage": "Upload Reference Image",
+      "referenceImageHint": "Local images + history images will be used as references for regeneration",
+      "noReferenceImage": "No reference images attached",
+      "useAsReference": "Set as Reference"
     },
     "script": {
       "searchPlaceholder": "Tìm kiếm tên kịch bản...",

--- a/src/locales/language/zh-CN.json
+++ b/src/locales/language/zh-CN.json
@@ -990,7 +990,10 @@
         "emptyPrompt": "勾选的数据{emptyPromptNames}提示词为空,请先生成提示词",
         "promptGenFail": "提示词生成失败",
         "saveSuccess": "修改提示词成功",
-        "saveFailed": "提示词修改失败"
+        "saveFailed": "提示词修改失败",
+        "imageTooLarge": "图片大小不能超过 10MB",
+        "uploadSuccess": "上传成功",
+        "uploadFailed": "上传失败"
       },
       "history": "历史图片",
       "confirmReplace": "确认替换",
@@ -1003,7 +1006,12 @@
       "cancelGeneration": "取消生成",
       "selectGenerating": "选择正在生成项",
       "noGenerating": "没有正在生成的数据",
-      "checkNumber": "选择数量"
+      "checkNumber": "选择数量",
+      "assetsReferenceImageLabel": "关联参考图片",
+      "uploadReferenceImage": "上传参考图片",
+      "referenceImageHint": "本地图片 + 历史图片均会作为重新生成的参考图",
+      "noReferenceImage": "暂未关联参考图片",
+      "useAsReference": "设为参考图"
     },
     "script": {
       "searchPlaceholder": "搜索剧本名称...",

--- a/src/locales/language/zh-TW.json
+++ b/src/locales/language/zh-TW.json
@@ -760,7 +760,10 @@
         "replaceSuccess": "替換成功",
         "promptGenFail": "提示詞生成失敗",
         "saveSuccess": "修改提示詞成功",
-        "saveFailed": "提示詞修改失敗"
+        "saveFailed": "提示詞修改失敗",
+        "imageTooLarge": "圖片大小不能超過 10MB",
+        "uploadSuccess": "上傳成功",
+        "uploadFailed": "上傳失敗"
       },
       "history": "歷史圖片",
       "confirmReplace": "確認替換",
@@ -773,7 +776,12 @@
       "cancelGeneration": "取消生成",
       "selectGenerating": "選擇正在產生項",
       "noGenerating": "沒有正在產生的數據",
-      "checkNumber": "選擇數量"
+      "checkNumber": "選擇數量",
+      "assetsReferenceImageLabel": "關聯參考圖片",
+      "uploadReferenceImage": "上傳參考圖片",
+      "referenceImageHint": "本地圖片 + 歷史圖片均會作為重新生成的參考圖",
+      "noReferenceImage": "暫未關聯參考圖片",
+      "useAsReference": "設為參考圖"
     },
     "script": {
       "searchPlaceholder": "搜尋劇本名稱...",

--- a/src/views/cornerScape/index.vue
+++ b/src/views/cornerScape/index.vue
@@ -183,10 +183,15 @@
                 v-for="item in currentItem.historyImages"
                 :key="item.id"
                 class="historyImageItem"
-                :class="{ selected: selectedHistoryId === item.id }"
+                :class="{ selected: selectedHistoryId === item.id, inReference: editForm.relepedImage.some((i) => i.id === item.id) }"
                 @click.stop="toggleHistorySelect(item.id)">
                 <t-image :src="item.filePath" :style="{ width: '100px', minWidth: '100px', height: '100px' }" :lazy="true" fit="contain" />
               </div>
+            </div>
+            <div class="historyActions" v-if="currentItem.historyImages.length">
+              <t-button size="small" theme="default" variant="outline" :disabled="!selectedHistoryId" @click.stop="addHistoryImageToReferences(selectedHistoryId)">
+                {{ $t("workbench.cornerScape.useAsReference") }}
+              </t-button>
             </div>
           </t-form-item>
           <t-form-item :label="$t('workbench.cornerScape.genModel')">
@@ -219,6 +224,24 @@
                 </t-tag>
               </div>
               <div v-else class="assets-empty">{{ $t("workbench.cornerScape.noAudio") }}</div>
+            </div>
+          </t-form-item>
+          <t-form-item :label="$t('workbench.cornerScape.assetsReferenceImageLabel')">
+            <div class="referenceImageBox">
+              <div class="referenceImageActions">
+                <t-button size="small" theme="primary" variant="outline" @click="uploadReferenceImage">
+                  <template #icon><i-upload-one /></template>
+                  {{ $t("workbench.cornerScape.uploadReferenceImage") }}
+                </t-button>
+                <span class="referenceImageHint">{{ $t("workbench.cornerScape.referenceImageHint") }}</span>
+              </div>
+              <div class="referenceImageList" v-if="editForm.relepedImage.length">
+                <div v-for="img in editForm.relepedImage" :key="img.id" class="referenceImageItem">
+                  <t-image :src="img.filePath" :style="{ width: '60px', height: '60px' }" fit="cover" />
+                  <i-close size="14" class="referenceImageRemove" @click.stop="removeReferenceImage(img.id)" />
+                </div>
+              </div>
+              <div v-else class="assets-empty">{{ $t("workbench.cornerScape.noReferenceImage") }}</div>
             </div>
           </t-form-item>
           <t-form-item>
@@ -475,6 +498,7 @@ const editForm = reactive({
   describe: "",
   promptState: "",
   relepedAudio: [] as { id: number; name: string }[],
+  relepedImage: [] as { id: number; filePath: string }[],
 });
 
 async function openDrawer(item: DataItem) {
@@ -491,6 +515,7 @@ async function openDrawer(item: DataItem) {
   editForm.describe = item.describe || "";
   editForm.promptState = item.promptState;
   editForm.relepedAudio = item?.relepedAudio ?? [];
+  editForm.relepedImage = item?.relepedImage ?? [];
 
   drawerVisible.value = true;
   // 重新获取最新数据（含历史图片）
@@ -546,6 +571,7 @@ function regenerateItem() {
         projectId: project.value?.id,
         name: item.name ?? $t("workbench.cornerScape.unnamed"),
         base64: "",
+        imageIds: editForm.relepedImage.map((i) => i.id),
         prompt: editForm.prompt,
         model: selectValue.value,
         id: item.id,
@@ -971,6 +997,66 @@ async function selectAudio() {
       audioIds: editForm.relepedAudio.map((i) => i.id),
     });
   }
+}
+
+// 打开文件选择器让用户上传本地图片
+function uploadReferenceImage() {
+  const input = document.createElement("input");
+  input.type = "file";
+  input.accept = "image/png,image/jpeg,image/jpg,image/webp";
+  input.onchange = async (e: any) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > 10 * 1024 * 1024) {
+      window.$message.warning($t("workbench.cornerScape.msg.imageTooLarge"));
+      return;
+    }
+    try {
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+      const { data } = await axios.post("/cornerScape/uploadReferenceImage", {
+        projectId: project.value?.id,
+        assetsId: editForm.assetsId,
+        base64Data: base64,
+      });
+      // 添加到本地列表并立即保存绑定
+      const newImg = { id: data.imageId, filePath: data.url };
+      editForm.relepedImage = [...editForm.relepedImage, newImg];
+      await axios.post("/cornerScape/updateAssetsImage", {
+        assetsId: editForm.assetsId,
+        imageIds: editForm.relepedImage.map((i) => i.id),
+      });
+      window.$message.success($t("workbench.cornerScape.msg.uploadSuccess"));
+    } catch (err: any) {
+      window.$message.error(err?.message ?? $t("workbench.cornerScape.msg.uploadFailed"));
+    }
+  };
+  input.click();
+}
+
+// 从历史图片勾选加入关联参考图
+async function addHistoryImageToReferences(imgId: number) {
+  if (editForm.relepedImage.some((i) => i.id === imgId)) return;
+  const target = currentItem.value?.historyImages?.find((h) => h.id === imgId);
+  if (!target) return;
+  editForm.relepedImage = [...editForm.relepedImage, { id: target.id, filePath: target.filePath }];
+  await axios.post("/cornerScape/updateAssetsImage", {
+    assetsId: editForm.assetsId,
+    imageIds: editForm.relepedImage.map((i) => i.id),
+  });
+}
+
+// 移除关联参考图
+async function removeReferenceImage(id: number) {
+  editForm.relepedImage = editForm.relepedImage.filter((i) => i.id !== id);
+  await axios.post("/cornerScape/updateAssetsImage", {
+    assetsId: editForm.assetsId,
+    imageIds: editForm.relepedImage.map((i) => i.id),
+  });
 }
 </script>
 


### PR DESCRIPTION
Add a 'Reference Images' section to the asset detail drawer in cornerScape/index.vue, allowing users to:
- Upload local images (PNG/JPG/WebP) -> saved as o_image + bound via /cornerScape/uploadReferenceImage + /cornerScape/updateAssetsImage
- Mark any history image as a reference via a 'Set as Reference' button
- Remove individual reference images
- All bound images are sent as imageIds to /assetsGenerate/generateAssets on regeneration, becoming the referenceList for image model

i18n: 8 new keys added to all 7 locale files (zh-CN/zh-TW/en/ja/vi/th/ru).