### PR TITLE
fix(workbench): 保留视频参考素材类型

### DIFF
--- a/src/views/production/components/workbench/generate/components/track.vue
+++ b/src/views/production/components/workbench/generate/components/track.vue
@@ -288,7 +288,7 @@ function batchGenText() {
     const trackId = track.id;
     let info = [];
     if (props.modelParmas.mode == "text") {
-      info = track?.medias.map(({ id, sources }) => ({ id, sources }));
+      info = track?.medias.map(({ id, sources, fileType }) => ({ id, sources, fileType }));
     } else {
       info = getTrackUploadInfo(track);
     }
@@ -331,12 +331,15 @@ function getTrackUploadInfo(track: TrackItem, filterEmpty = false) {
 
   if (track.id === activeTrackId) {
     const items = props.imageList as UploadItem[];
-    return (filterEmpty ? items.filter((item) => Boolean(item.src)) : items).map(({ id, sources }) => ({
+    return (filterEmpty ? items.filter((item) => Boolean(item.src)) : items).map(({ id, sources, fileType }) => ({
       id,
       sources: (sources ?? "storyboard") as string,
+      fileType,
     }));
   }
-  return track.medias.filter((m) => !filterEmpty || Boolean(m.src)).map(({ id, sources }) => ({ id, sources: (sources ?? "storyboard") as string }));
+  return track.medias
+    .filter((m) => !filterEmpty || Boolean(m.src))
+    .map(({ id, sources, fileType }) => ({ id, sources: (sources ?? "storyboard") as string, fileType }));
 }
 const generateVideoLoad = ref(false);
 /** 批量为已勾选轨道生成视频 */

--- a/src/views/production/components/workbench/generate/index.vue
+++ b/src/views/production/components/workbench/generate/index.vue
@@ -301,11 +301,11 @@ function handlePromptBlur() {
 async function genText() {
   const track = currentTrack.value;
   if (track.id == null || track.state === "生成中") return;
-  let info: { id: number; sources: string }[] = [];
+  let info: { id: number; sources: string; fileType?: string }[] = [];
   const currentTrackId = track.id;
   const rawMedias = (track.medias ?? []) as UploadItem[];
   if (modelParmas.value.mode == "text") {
-    info = rawMedias.map(({ id, sources }) => ({ id: id!, sources }));
+    info = rawMedias.map(({ id, sources, fileType }) => ({ id: id!, sources, fileType }));
   } else {
     const frameMode = ["startEndRequired", "endFrameOptional", "startFrameOptional"];
     const preSliced = frameMode.includes(modelParmas.value.mode)
@@ -313,7 +313,9 @@ async function genText() {
       : modelParmas.value.mode === "singleImage"
         ? rawMedias.slice(0, 1)
         : rawMedias;
-    const filtered = preSliced.filter((item) => typeof item.id === "number" && !isNaN(item.id)).map(({ id, sources }) => ({ id: id!, sources }));
+    const filtered = preSliced
+      .filter((item) => typeof item.id === "number" && !isNaN(item.id))
+      .map(({ id, sources, fileType }) => ({ id: id!, sources, fileType }));
     if (frameMode.includes(modelParmas.value.mode)) info = filtered.slice(0, 2);
     else if (modelParmas.value.mode === "singleImage") info = filtered.slice(0, 1);
     else info = filtered;
@@ -406,7 +408,7 @@ async function generateVideo() {
                       : imageList.value;
                   const filtered = preSliced
                     .filter((item) => Boolean(item.src) && typeof item.id === "number" && !isNaN(item.id))
-                    .map(({ id, sources }) => ({ id, sources }));
+                    .map(({ id, sources, fileType }) => ({ id, sources, fileType }));
                   if (frameMode.includes(modelParmas.value.mode)) return filtered.slice(0, 2);
                   if (modelParmas.value.mode === "singleImage") return filtered.slice(0, 1);
                   return filtered;


### PR DESCRIPTION
## 问题背景

视频工作台在组装提示词与视频生成请求时，部分路径只保留素材 ID 和来源，导致图片、视频、音频的 `fileType` 丢失。后端因而无法稳定生成 `@图片N`、`@视频N`、`@音频N` 的独立引用。

配套后端能力已通过 [Toonflow-app PR #245](https://github.com/HBAI-Ltd/Toonflow-app/pull/245) 合并。本 PR 仅补齐前端请求中的媒体类型透传。

## 修改内容

- 单条提示词请求的 text 与非 text 路径均保留 `fileType`。
- 批量提示词请求保留 `fileType`。
- 单条和批量视频生成请求保留 `fileType`。
- 不改变接口路径及现有请求字段，仅补充后端已支持的可选字段。

## 提交边界

- 本 PR 只修改两个视频工作台 Vue 文件。
- 不提交前端单元测试文件，由测试同事在本地完成业务验证。
- 不提交构建产物；发布时仍由项目构建流程生成。

## 验证

- `npm run build-only`：通过，11096 modules transformed。
- `git diff --check upstream/develop...HEAD`：通过。
- PR 分支已整理为单一核心提交。

## 兼容性与风险

- `fileType` 是后端可选字段；旧数据或缺少该字段的请求仍由后端执行兼容回退。
- 改动仅影响媒体类型透传，不改变素材筛选、顺序或首尾帧裁剪逻辑。

Closes HBAI-Ltd/Toonflow-app#195
