### PR TITLE
Fix 分镜面板不支持整板重做,系统不存在删除旧分镜的 Agent 工具，AI 无法在重做前清空面板，导致新旧分镜混合

### DIFF
--- a/src/stores/productionAgent.ts
+++ b/src/stores/productionAgent.ts
@@ -184,6 +184,16 @@ function makeProductionAgentStore(projectId: string) {
             deriveAssetList.splice(index, 1);
             callback({ success: true, message: $t("storyboard.assets.derivativeDelSuccess") });
           });
+          s.on("delStoryboard", async (data, callback) => {
+            const deletedIds: number[] = data.ids;
+            if (!deletedIds || !deletedIds.length) {
+              return callback({ success: false, message: "未指定要删除的分镜" });
+            }
+            flowData.value.storyboard = flowData.value.storyboard.filter(
+              (item) => !deletedIds.includes(item.id!),
+            );
+            callback({ success: true, message: "分镜已从面板移除" });
+          });
           s.on("generateDeriveAsset", async (data, callback) => {
             const assetsData = await batchGenerateAssets(data.ids);
             callback({ success: true, message: assetsData });


### PR DESCRIPTION
## 问题
分镜面板不支持整板重做。用户发出重做指令后，AI 会追加新分镜但无法清除旧分镜，导致面板中新旧分镜混合重复。

## 修复
在 src/stores/productionAgent.ts 中新增 delStoryboard 事件监听，与后端 del_flowData_storyboard 工具配套：收到 { ids } 后从 flowData.storyboard 中 filter 移除旧分镜，面板即时更新，避免新旧重复。

## 验证
- 编译产物中可检索到 delStoryboard 事件监听逻辑
- 配合后端 PR [Fix storyboard panel 20260731-#248](https://github.com/HBAI-Ltd/Toonflow-app/pull/248) 联调：整板重做后前端面板仅展示新分镜，无新旧重复