### PR TITLE
Replace media generation with prompt uploads

### DIFF
--- a/src/components/setting/components/vendorTest/ImageModelTest.vue
+++ b/src/components/setting/components/vendorTest/ImageModelTest.vue
@@ -45,16 +45,18 @@
           <img :src="resultUrl" alt="generated" />
         </div>
       </div>
-      <div v-else-if="loading" class="loadingSection">
-        <t-loading size="large" :text="$t('settings.vendor.generating')" />
-      </div>
+      <input ref="resultImageInputRef" type="file" accept="image/*" style="display: none" @change="uploadResultImage" />
 
       <!-- 底部操作 -->
       <div class="dialogFooter">
         <t-button variant="outline" @click="visible = false">{{ $t("settings.vendor.test.cancel") }}</t-button>
-        <t-button theme="primary" :loading="loading" :disabled="!canSubmit" @click="handleTest">
-          <template #icon><i-lightning theme="outline" /></template>
-          {{ $t("settings.vendor.test.startTest") }}
+        <t-button theme="primary" :disabled="!canSubmit" @click="copyManualPrompt">
+          <template #icon><t-icon name="file-copy" /></template>
+          复制完整生图提示词
+        </t-button>
+        <t-button theme="success" variant="outline" @click="resultImageInputRef?.click()">
+          <template #icon><t-icon name="upload" /></template>
+          上传生成图片
         </t-button>
       </div>
     </div>
@@ -62,7 +64,7 @@
 </template>
 
 <script setup lang="ts">
-import axios from "@/utils/axios";
+import { buildManualImagePrompt, copyText, fileToDataUrl } from "@/utils/manualMedia";
 
 type ImageMode = "text" | "singleImage" | "multiReference";
 const visible = defineModel<boolean>("modelVisible");
@@ -106,6 +108,7 @@ const imagePreview = ref("");
 const imageInputRef = ref<HTMLInputElement | null>(null);
 const loading = ref(false);
 const resultUrl = ref("");
+const resultImageInputRef = ref<HTMLInputElement | null>(null);
 
 const canSubmit = computed(() => {
   if (loading.value) return false;
@@ -134,34 +137,28 @@ function handleDrop(e: DragEvent) {
   }
 }
 
-const fileToDataURL = (file: File) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result as string); // data:image/...;base64,xxxx
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
-async function handleTest() {
-  loading.value = true;
-  resultUrl.value = "";
+async function copyManualPrompt() {
   try {
-    const payload: Record<string, any> = {
-      modelName: props.modelName,
-      id: props.vendorId,
-    };
-    const p = prompt.value.trim();
-    if (p) payload.prompt = p;
-    if (imageFile.value) {
-      payload.imageBase64 = await fileToDataURL(imageFile.value); // 带前缀 data:image/...;base64,
-    }
-    const { data } = await axios.post("/setting/vendorConfig/modelTest/imageTest", payload);
-    resultUrl.value = data;
-    window.$message.success($t("settings.vendor.msg.imageGenSuccess"));
+    await copyText(
+      buildManualImagePrompt({
+        category: "模型测试",
+        name: props.modelName,
+        prompt: prompt.value,
+        referenceCount: imageFile.value ? 1 : 0,
+      }),
+    );
+    window.$message.success("完整生图提示词已复制，请在外部工具生成后上传结果");
   } catch (e: any) {
-    window.$message.error(e.message ?? `${$t("settings.vendor.msg.requestFailed")}`);
-  } finally {
-    loading.value = false;
+    window.$message.error(e.message ?? "复制完整生图提示词失败");
   }
+}
+
+async function uploadResultImage(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (!file) return;
+  resultUrl.value = await fileToDataUrl(file);
+  (event.target as HTMLInputElement).value = "";
+  window.$message.success("生成图片已上传到测试结果区");
 }
 
 function handleClose() {

--- a/src/components/setting/components/vendorTest/VideoModelTest.vue
+++ b/src/components/setting/components/vendorTest/VideoModelTest.vue
@@ -148,16 +148,18 @@
         <div class="resultLabel">{{ $t("settings.vendor.test.result") }}</div>
         <video :src="resultUrl" controls autoplay loop class="resultVideo" />
       </div>
-      <div v-else-if="loading" class="loadingSection">
-        <t-loading size="large" :text="$t('settings.vendor.videoGenerating')" />
-      </div>
+      <input ref="resultVideoInputRef" type="file" accept="video/*" style="display: none" @change="uploadResultVideo" />
 
       <!-- 底部操作 -->
       <div class="dialogFooter">
         <t-button variant="outline" @click="visible = false">{{ $t("settings.vendor.test.cancel") }}</t-button>
-        <t-button theme="primary" :loading="loading" @click="handleTest">
-          <template #icon><i-lightning theme="outline" /></template>
-          {{ $t("settings.vendor.test.startTest") }}
+        <t-button theme="primary" :disabled="!canSubmit" @click="copyManualPrompt">
+          <template #icon><t-icon name="file-copy" /></template>
+          复制完整视频提示词
+        </t-button>
+        <t-button theme="success" variant="outline" @click="resultVideoInputRef?.click()">
+          <template #icon><t-icon name="upload" /></template>
+          上传生成视频
         </t-button>
       </div>
     </div>
@@ -165,10 +167,10 @@
 </template>
 
 <script setup lang="ts">
-import axios from "@/utils/axios";
 import ImageUploadBox from "./ImageUploadBox.vue";
 import VideoUploadBox from "./VideoUploadBox.vue";
 import AudioUploadBox from "./AudioUploadBox.vue";
+import { buildManualVideoPrompt, copyText, fileToDataUrl } from "@/utils/manualMedia";
 
 type VideoRawMode =
   | "singleImage"
@@ -296,6 +298,7 @@ const uploadedVideos = ref<(File | null)[]>(Array(30).fill(null));
 const uploadedAudios = ref<(File | null)[]>(Array(30).fill(null));
 const loading = ref(false);
 const resultUrl = ref("");
+const resultVideoInputRef = ref<HTMLInputElement | null>(null);
 
 function resetUploads() {
   uploadedImages.value = Array(30).fill(null);
@@ -310,7 +313,7 @@ const canSubmit = computed(() => {
   if (selectedMode.value === "startEndRequired") return !!uploadedImages.value[0] && !!uploadedImages.value[1];
   if (selectedMode.value === "endFrameOptional") return !!uploadedImages.value[0];
   if (selectedMode.value === "startFrameOptional") return !!uploadedImages.value[1];
-  if (selectedMode.value.startsWith("multiRef:")) {
+  if (selectedMode.value.startsWith("[")) {
     // 验证所有非可选 ref 都已上传
     for (let rIdx = 0; rIdx < currentMultiRefs.value.length; rIdx++) {
       const ref = currentMultiRefs.value[rIdx];
@@ -331,53 +334,33 @@ function getRefLabel(ref: RefItem): string {
   if (ref.type === "videoReference") return `${$t("settings.vendor.videoRef")} (×${ref.count})`;
   return `${$t("settings.vendor.audioRef")} (×${ref.count})`;
 }
-function fileToDataURL(file: File) {
-  return new Promise((resolve, reject) => {
-    const r = new FileReader();
-    r.onload = () => resolve(r.result); // data:xxx/yyy;base64,....
-    r.onerror = reject;
-    r.readAsDataURL(file);
-  });
+async function copyManualPrompt() {
+  try {
+    const references = [
+      ...uploadedImages.value.filter(Boolean).map((file) => ({ fileType: "image", name: file?.name })),
+      ...uploadedVideos.value.filter(Boolean).map((file) => ({ fileType: "video", name: file?.name })),
+      ...uploadedAudios.value.filter(Boolean).map((file) => ({ fileType: "audio", name: file?.name })),
+    ];
+    await copyText(
+      buildManualVideoPrompt({
+        name: props.modelName,
+        prompt: prompt.value,
+        mode: selectedMode.value,
+        references,
+      }),
+    );
+    window.$message.success("完整视频提示词已复制，请在外部工具生成后上传结果");
+  } catch (e: any) {
+    window.$message.error(e?.message ?? "复制完整视频提示词失败");
+  }
 }
 
-function mapTopType(mime = "") {
-  if (mime.startsWith("image/")) return "image";
-  if (mime.startsWith("video/")) return "video";
-  if (mime.startsWith("audio/")) return "audio";
-  return ""; // 不认识就空
-}
-async function encodeFiles(files: File[]) {
-  const valid = (files || []).filter(Boolean);
-  return Promise.all(
-    valid.map(async (f) => ({
-      type: mapTopType(f.type),
-      base64: await fileToDataURL(f), // 带前缀 data:...;base64,...
-    })),
-  );
-}
-async function handleTest() {
-  loading.value = true;
-  resultUrl.value = "";
-  try {
-    const payload = {
-      modelName: props.modelName,
-      id: props.vendorId,
-      mode: selectedMode.value,
-      ...(prompt.value.trim() ? { prompt: prompt.value.trim() } : {}),
-      images: await encodeFiles(uploadedImages.value.filter(Boolean) as File[]),
-      videos: await encodeFiles(uploadedVideos.value.filter(Boolean) as File[]),
-      audios: await encodeFiles(uploadedAudios.value.filter(Boolean) as File[]),
-    };
-    const { data } = await axios.post("/setting/vendorConfig/modelTest/videoTest", payload, {
-      timeout: 30 * 60 * 1000,
-    });
-    resultUrl.value = data;
-    window.$message.success($t("settings.vendor.msg.videoGenSuccess"));
-  } catch (e: any) {
-    window.$message.error(e?.message ?? `${$t("settings.vendor.msg.requestFailed")}`);
-  } finally {
-    loading.value = false;
-  }
+async function uploadResultVideo(event: Event) {
+  const file = (event.target as HTMLInputElement).files?.[0];
+  if (!file) return;
+  resultUrl.value = await fileToDataUrl(file);
+  (event.target as HTMLInputElement).value = "";
+  window.$message.success("生成视频已上传到测试结果区");
 }
 
 function handleClose() {

--- a/src/stores/productionAgent.ts
+++ b/src/stores/productionAgent.ts
@@ -6,6 +6,20 @@ import type { FlowData, Storyboard } from "@/views/production/utils/flowBuilder"
 import type { ChatMessagesData } from "@tdesign-vue-next/chat";
 import { useThrottleFn } from "@vueuse/core";
 
+function isExecutionDirectorMessage(message: ChatMessagesData): boolean {
+  return (message as ChatMessagesData & { name?: string }).name === "执行导演";
+}
+
+function expandExecutionDirectorThinking(message: ChatMessagesData): ChatMessagesData {
+  if (!isExecutionDirectorMessage(message) || message.role !== "assistant") return message;
+  message.content?.forEach((content) => {
+    if (content.type === "thinking") {
+      content.ext = { ...content.ext, collapsed: false };
+    }
+  });
+  return message;
+}
+
 function makeProductionAgentStore(projectId: string) {
   return defineStore(`productionAgent-${projectId}`, () => {
     const defMsg: ChatMessagesData[] = [
@@ -54,6 +68,7 @@ function makeProductionAgentStore(projectId: string) {
         { tag: "storyboardTable", keepInMessage: false },
         { tag: "storyboardItem", keepInMessage: false },
       ],
+      defaultThinkingCollapsed: (message) => !isExecutionDirectorMessage(message),
       onXmlTag: async (data) => {
         const { tag, value, children, attrs, isComplete, status } = data;
         if (tag === "script") {
@@ -422,7 +437,7 @@ function makeProductionAgentStore(projectId: string) {
         agentType: "productionAgent",
       });
       messages.value = [];
-      messages.value = [...defMsg, ...data];
+      messages.value = [...defMsg, ...data.map(expandExecutionDirectorThinking)];
       loadingHistory.value = false;
     }
 

--- a/src/stores/productionAgent.ts
+++ b/src/stores/productionAgent.ts
@@ -231,67 +231,11 @@ function makeProductionAgentStore(projectId: string) {
       });
       flowData.value = data;
     }
-    async function batchGenerateStoryboard(allIds: number[], compulsory: boolean = false) {
-      try {
-        const { data } = await axios.post("/production/storyboard/batchGenerateImage", {
-          scriptId: episodesId.value,
-          projectId: projectId,
-          storyboardIds: allIds,
-          concurrentCount: settingStore().otherSetting.assetsBatchGenereateSize,
-          compulsory,
-        });
-        if (data) {
-          if (flowData.value.storyboard.length === 0) {
-            flowData.value.storyboard = data;
-            return data;
-          } else {
-            flowData.value.storyboard.forEach((item) => {
-              const findData = data.find((i: any) => i.id == item.id);
-              if (findData) {
-                item.state = findData.state;
-                item.src = findData.src;
-              }
-            });
-          }
-        }
-        return data;
-      } catch (e) {
-        window.$message.error((e as any)?.message);
-      }
+    async function batchGenerateStoryboard(allIds: number[], _compulsory: boolean = false) {
+      return flowData.value.storyboard.filter((item) => item.id != null && allIds.includes(item.id));
     }
     async function batchGenerateAssets(allIds: number[]) {
-      flowData.value.assets.forEach((asset) => {
-        if (asset.derive) {
-          asset.derive.forEach((derive) => {
-            if (allIds.includes(derive.id)) {
-              derive.state = "生成中" as "未生成" | "生成中" | "已完成" | "生成失败";
-            }
-          });
-        }
-      });
-      try {
-        const { data } = await axios.post("/production/assets/batchGenerateAssetsImage", {
-          assetIds: allIds,
-          projectId: projectId,
-          scriptId: episodesId.value,
-          concurrentCount: settingStore().otherSetting.assetsBatchGenereateSize,
-        });
-        if (data) {
-          data.forEach((record: { id: number; state: "未生成" | "生成中" | "已完成" | "生成失败"; src: string }) => {
-            flowData.value.assets.forEach((asset) => {
-              if (asset.derive) {
-                asset.derive.forEach((derive) => {
-                  if (derive.id === record.id) {
-                    derive.state = record.state;
-                    derive.src = record.src;
-                  }
-                });
-              }
-            });
-          });
-        }
-        return data;
-      } catch (e) {}
+      return flowData.value.assets.flatMap((asset) => asset.derive ?? []).filter((derive) => allIds.includes(derive.id));
     }
     const assetsNotStateImageIds = computed(() => {
       const ids: number[] = [];

--- a/src/stores/productionAgent.ts
+++ b/src/stores/productionAgent.ts
@@ -55,12 +55,12 @@ function makeProductionAgentStore(projectId: string) {
         { tag: "storyboardItem", keepInMessage: false },
       ],
       onXmlTag: async (data) => {
-        const { tag, value, children, attrs, status } = data;
+        const { tag, value, children, attrs, isComplete, status } = data;
         if (tag === "script") {
           flowData.value.script = value ?? "";
         } else if (tag === "scriptPlan") {
           flowData.value.scriptPlan = value ?? "";
-        } else if (tag === "storyboardTable") {
+        } else if (tag === "storyboardTable" && isComplete && status === "complete") {
           flowData.value.storyboardTable = value ?? "";
         }
         // else if (tag === "storyboardItem") {

--- a/src/utils/manualMedia.ts
+++ b/src/utils/manualMedia.ts
@@ -1,0 +1,130 @@
+export interface ManualImagePromptInput {
+  name?: string | null;
+  category?: string | null;
+  prompt?: string | null;
+  description?: string | null;
+  artStyle?: string | null;
+  aspectRatio?: string | null;
+  resolution?: string | null;
+  referenceCount?: number;
+}
+
+export interface ManualVideoPromptInput {
+  name?: string | null;
+  prompt?: string | null;
+  duration?: number | null;
+  aspectRatio?: string | null;
+  resolution?: string | null;
+  mode?: string | null;
+  audio?: boolean;
+  references?: Array<{
+    fileType?: string;
+    name?: string;
+    prompt?: string;
+    sources?: string;
+  }>;
+}
+
+export interface BatchPromptItem {
+  title: string;
+  prompt: string;
+}
+
+const imageCategoryLabels: Record<string, string> = {
+  role: "角色",
+  scene: "场景",
+  tool: "道具",
+  props: "道具",
+  storyboard: "分镜",
+};
+
+function text(value: unknown, fallback = "未指定"): string {
+  const normalized = String(value ?? "").trim();
+  return normalized || fallback;
+}
+
+export function buildManualImagePrompt(input: ManualImagePromptInput): string {
+  const category = imageCategoryLabels[text(input.category, "")] ?? text(input.category, "图片");
+  const referenceInstruction =
+    (input.referenceCount ?? 0) > 0
+      ? `使用 ${input.referenceCount} 张参考图保持主体身份、服装、场景结构和视觉连续性，不要照搬参考图中的瑕疵。`
+      : "无参考图，严格依据文字设定生成。";
+
+  return [
+    "【图片生成提示词】",
+    `用途：${category}图`,
+    `名称：${text(input.name)}`,
+    `画风：${text(input.artStyle)}`,
+    `画幅比例：${text(input.aspectRatio, "跟随项目设置")}`,
+    `清晰度：${text(input.resolution, "高质量")}`,
+    `参考图要求：${referenceInstruction}`,
+    "",
+    "【主体与画面要求】",
+    text(input.prompt, text(input.description)),
+    "",
+    "【补充约束】",
+    "主体特征前后一致，构图完整，透视与解剖自然，材质和光影符合场景；画面中不要出现水印、Logo、边框、说明文字、乱码或无关元素。",
+    "",
+    "【负面提示词】",
+    "低清晰度、模糊、噪点、过曝、欠曝、畸形、额外肢体、缺失肢体、错误手指、重复主体、比例失衡、透视错误、文字、水印、Logo、边框、拼贴。",
+  ].join("\n");
+}
+
+export function buildManualVideoPrompt(input: ManualVideoPromptInput): string {
+  const references = input.references ?? [];
+  const referenceLines = references.length
+    ? references.map((item, index) => {
+        const typeLabel = item.fileType === "audio" ? "音频" : item.fileType === "video" ? "视频" : "图片";
+        const detail = text(item.name || item.prompt, item.sources === "assets" ? "资产素材" : "分镜素材");
+        return `- @${typeLabel}${index + 1}：${detail}`;
+      })
+    : ["- 无参考素材，按纯文本要求生成。"];
+
+  return [
+    "【视频生成提示词】",
+    `片段：${text(input.name, "当前视频轨道")}`,
+    `时长：${input.duration ?? "跟随项目设置"} 秒`,
+    `画幅比例：${text(input.aspectRatio, "跟随项目设置")}`,
+    `分辨率：${text(input.resolution, "高质量")}`,
+    `生成模式：${text(input.mode, "按提示词生成")}`,
+    `音频：${input.audio ? "需要生成或保留匹配的声音" : "不要求模型生成音频"}`,
+    "",
+    "【参考素材对应关系】",
+    ...referenceLines,
+    "",
+    "【完整视频描述】",
+    text(input.prompt),
+    "",
+    "【连续性与输出要求】",
+    "保持角色身份、服装、道具、场景和光影连续；动作符合物理规律，镜头运动平稳，首尾衔接自然。不要出现水印、Logo、字幕、乱码、闪烁、跳帧、主体突变、肢体畸变或画面撕裂。",
+  ].join("\n");
+}
+
+export function buildBatchPrompt(items: BatchPromptItem[]): string {
+  return items.map((item, index) => `===== ${index + 1}. ${item.title} =====\n${item.prompt}`).join("\n\n");
+}
+
+export async function copyText(content: string): Promise<void> {
+  if (navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(content);
+    return;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = content;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand("copy");
+  textarea.remove();
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () => reject(reader.error ?? new Error("读取文件失败"));
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/utils/useChat.ts
+++ b/src/utils/useChat.ts
@@ -48,6 +48,7 @@ export interface XmlTagEvent {
   value: string;
   attrs: Record<string, string>;
   children: XmlChildItem[];
+  isComplete: boolean;
   status: ChatMessageStatus;
 }
 
@@ -280,7 +281,13 @@ export function useChat(options: UseChatOptions) {
       if (parsed === null) continue;
 
       const { value, isComplete } = parsed;
-      const eventStatus = isComplete ? (status === "error" || status === "stop" ? status : "complete") : status;
+      const eventStatus = isComplete
+        ? status === "error" || status === "stop"
+          ? status
+          : "complete"
+        : status === "complete"
+          ? "error"
+          : status;
 
       const shouldEmit = prevState[tag] !== value || eventStatus === "complete";
       if (!shouldEmit) continue;
@@ -298,6 +305,7 @@ export function useChat(options: UseChatOptions) {
         value,
         attrs: parsed.attrs,
         children: parsed.children,
+        isComplete,
         status: eventStatus,
       });
     }

--- a/src/utils/useChat.ts
+++ b/src/utils/useChat.ts
@@ -77,11 +77,21 @@ export interface UseChatOptions {
   autoConnect?: boolean;
   xmlTags?: Array<string | XmlTagOption>;
   keepXmlInMessage?: boolean;
+  defaultThinkingCollapsed?: boolean | ((message: ChatMessagesData) => boolean);
   onXmlTag?: (event: XmlTagEvent) => void;
   onError?: (error: { code: string; message: string }) => void;
   onConnect?: () => void;
   onDisconnect?: () => void;
   manageLifecycle?: boolean;
+}
+
+export function appendThinkingDelta(currentData: Record<string, any> | null | undefined, delta: Record<string, any>) {
+  const currentThinkingText = typeof currentData?.text === "string" ? currentData.text : "";
+  return {
+    ...currentData,
+    ...delta,
+    text: currentThinkingText + (typeof delta.text === "string" ? delta.text : ""),
+  };
 }
 
 export function useChat(options: UseChatOptions) {
@@ -91,6 +101,7 @@ export function useChat(options: UseChatOptions) {
     autoConnect = true,
     xmlTags = [],
     keepXmlInMessage = true,
+    defaultThinkingCollapsed = true,
     onXmlTag,
     onError,
     onConnect,
@@ -118,6 +129,9 @@ export function useChat(options: UseChatOptions) {
   const hiddenXmlTags = normalizedXmlTagOptions.filter((item) => ((item.keepInMessage ?? keepXmlInMessage) ? false : true)).map((item) => item.tag);
   const emittedXmlState = new Map<string, Record<string, string>>();
   const rawContentState = new Map<string, string>();
+
+  const resolveDefaultThinkingCollapsed = (message: ChatMessagesData) =>
+    typeof defaultThinkingCollapsed === "function" ? defaultThinkingCollapsed(message) : defaultThinkingCollapsed;
 
   // 计算属性 - 修复：增加对内容流状态的判断
   const isGenerating = computed(() => {
@@ -399,6 +413,8 @@ export function useChat(options: UseChatOptions) {
 
       rawContentState.set(contentKey, nextRaw);
       syncContentDisplay(messageId, content);
+    } else if (content.type === "thinking" && strategy === "append" && typeof data === "object" && typeof data.text === "string") {
+      content.data = appendThinkingDelta(content.data, data);
     } else if (strategy === "append") {
       if (typeof data === "string") {
         appendStringData(content, data);
@@ -444,6 +460,9 @@ export function useChat(options: UseChatOptions) {
       if (data.role === "assistant") {
         const aiMessage = newMessage as AIMessage;
         aiMessage.content?.forEach((content) => {
+          if (content.type === "thinking") {
+            content.ext = { collapsed: resolveDefaultThinkingCollapsed(newMessage), ...content.ext };
+          }
           if (!isXmlTextContent(content)) return;
           rawContentState.set(getContentKey(data.id, content), content.data);
           syncContentDisplay(data.id, content);
@@ -515,7 +534,7 @@ export function useChat(options: UseChatOptions) {
         ...data.content,
         status: data.content.status || "pending",
         // thinking 内容块默认折叠
-        ...(data.content.type === "thinking" ? { ext: { collapsed: true, ...data.content.ext } } : {}),
+        ...(data.content.type === "thinking" ? { ext: { collapsed: resolveDefaultThinkingCollapsed(msg), ...data.content.ext } } : {}),
       };
 
       if (isXmlTextContent(content)) {

--- a/src/views/assets/components/batchGeneration.vue
+++ b/src/views/assets/components/batchGeneration.vue
@@ -13,9 +13,9 @@
       <div class="content">
         <div class="toolbar">
           <t-space>
-            <span class="selectedInfo">{{ $t('workbench.assets.batch.selected', { count: selectedRowKeys.length }) }}</span>
-            <t-button theme="primary" size="small" @click="handleSelectAll">{{ $t('workbench.assets.batch.selectAll') }}</t-button>
-            <t-button theme="default" size="small" @click="handleClearSelection">{{ $t('workbench.assets.batch.clearSelection') }}</t-button>
+            <span class="selectedInfo">{{ $t("workbench.assets.batch.selected", { count: selectedRowKeys.length }) }}</span>
+            <t-button theme="primary" size="small" @click="handleSelectAll">{{ $t("workbench.assets.batch.selectAll") }}</t-button>
+            <t-button theme="default" size="small" @click="handleClearSelection">{{ $t("workbench.assets.batch.clearSelection") }}</t-button>
           </t-space>
           <t-input v-model="searchText" :placeholder="$t('workbench.assets.searchPlaceholder')" clearable style="width: 400px; margin-left: 10px">
             <template #prefix-icon>
@@ -26,13 +26,13 @@
             <t-button theme="primary" @click="handleBatchGeneratePrompt" :loading="textLoading" :disabled="textLoading">
               <div class="ac">
                 <i-translate theme="outline" size="20" />
-                {{ $t('workbench.assets.generatePrompt') }}
+                {{ $t("workbench.assets.generatePrompt") }}
               </div>
             </t-button>
-            <t-button theme="primary" style="margin-left: 10px" @click="handleBatchGenerateImage" :loading="imageLoading" :disabled="imageLoading">
+            <t-button theme="primary" style="margin-left: 10px" @click="handleBatchGenerateImage">
               <div class="ac">
                 <i-pic theme="outline" size="20" />
-                {{ $t('workbench.assets.generateImage') }}
+                批量复制完整生图提示词
               </div>
             </t-button>
           </div>
@@ -62,7 +62,7 @@
                     </div>
                     <div v-if="row.filePath" class="imageHoverOverlay">
                       <t-icon name="browse" size="20px" />
-                      <span class="hoverText">{{ $t('workbench.assets.preview') }}</span>
+                      <span class="hoverText">{{ $t("workbench.assets.preview") }}</span>
                     </div>
                   </div>
                 </template>
@@ -78,8 +78,10 @@
       </div>
       <template #footer>
         <t-space>
-          <t-button theme="default" @click="handleCancel">{{ $t('workbench.assets.cancelBtn') }}</t-button>
-          <t-button theme="primary" @click="onConfirm" :disabled="selectedRowKeys.length === 0">{{ $t('workbench.assets.batch.saveSelected', { count: selectedRowKeys.length }) }}</t-button>
+          <t-button theme="default" @click="handleCancel">{{ $t("workbench.assets.cancelBtn") }}</t-button>
+          <t-button theme="primary" @click="onConfirm" :disabled="selectedRowKeys.length === 0">
+            {{ $t("workbench.assets.batch.saveSelected", { count: selectedRowKeys.length }) }}
+          </t-button>
         </t-space>
       </template>
     </t-dialog>
@@ -93,6 +95,7 @@ const { otherSetting } = storeToRefs(settingStore());
 import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
 import type { TableProps } from "tdesign-vue-next";
+import { buildBatchPrompt, buildManualImagePrompt, copyText } from "@/utils/manualMedia";
 
 const { project } = storeToRefs(projectStore());
 
@@ -105,21 +108,21 @@ const columns: TableProps["columns"] = [
   { colKey: "row-select", type: "multiple", width: 50, align: "center", fixed: "left" },
   {
     colKey: "filePath",
-    title: $t('workbench.assets.batch.colPreviewImg'),
+    title: $t("workbench.assets.batch.colPreviewImg"),
     width: 100,
     align: "center",
     cell: "preview",
   },
   {
     colKey: "name",
-    title: $t('workbench.assets.colName'),
+    title: $t("workbench.assets.colName"),
     width: 150,
     align: "left",
     ellipsis: true,
   },
   {
     colKey: "prompt",
-    title: $t('workbench.assets.colPrompt'),
+    title: $t("workbench.assets.colPrompt"),
     minWidth: 200,
     align: "left",
     ellipsis: true,
@@ -142,7 +145,6 @@ interface AssetItem {
 const tableData = ref<AssetItem[]>([]);
 const localData = ref<AssetItem[]>([]);
 const rowPromptLoading = ref<Record<number, boolean>>({});
-const rowImageLoading = ref<Record<number, boolean>>({});
 
 // 选中的行
 const selectedRowKeys = ref<number[]>([]);
@@ -230,7 +232,6 @@ async function handlePageChange(pageInfo: { current: number; pageSize: number })
 function closeModal(): void {
   // 取消正在进行的生成任务
   promptGenerateCancel.value = true;
-  imageGenerateCancel.value = true;
 
   batchGenerationShow.value = false;
   selectedRowKeys.value = [];
@@ -250,12 +251,12 @@ const emit = defineEmits(["update"]);
 
 async function onConfirm() {
   if (selectedRowKeys.value.length === 0) {
-    window.$message.warning($t('workbench.assets.selectAtLeastOne'));
+    window.$message.warning($t("workbench.assets.selectAtLeastOne"));
     return;
   }
   const selectedAssets = tableData.value.filter((item) => selectedRowKeys.value.includes(item.id));
   if (selectedAssets.length === 0) {
-    window.$message.error($t('workbench.assets.batch.selectToSave'));
+    window.$message.error($t("workbench.assets.batch.selectToSave"));
     return;
   }
 
@@ -280,12 +281,12 @@ async function onConfirm() {
       }
     });
 
-    window.$message.success($t('workbench.assets.batch.saveSuccess'));
+    window.$message.success($t("workbench.assets.batch.saveSuccess"));
     emit("update"); // 通知父组件更新数据
     closeModal();
   } catch (error) {
     console.error("保存失败:", error);
-    window.$message.error($t('workbench.assets.batch.saveFail'));
+    window.$message.error($t("workbench.assets.batch.saveFail"));
   }
 }
 const textLoading = ref(false);
@@ -294,7 +295,7 @@ const promptGenerateCancel = ref(false);
 async function handleBatchGeneratePrompt() {
   const selectedAssets = tableData.value.filter((item) => selectedRowKeys.value.includes(item.id));
   if (selectedAssets.length === 0) {
-    window.$message.error($t('workbench.assets.selectAtLeastOne'));
+    window.$message.error($t("workbench.assets.selectAtLeastOne"));
     return;
   }
   promptGenerateCancel.value = false;
@@ -302,13 +303,13 @@ async function handleBatchGeneratePrompt() {
   const batchSize = otherSetting.value.assetsBatchGenereateSize || 5; // 从设置中获取批量生成的大小，默认为5
   try {
     for (let i = 0; i < selectedAssets.length; i += batchSize) {
-      if (promptGenerateCancel.value) throw new Error($t('workbench.assets.batch.promptGenCancelled'));
+      if (promptGenerateCancel.value) throw new Error($t("workbench.assets.batch.promptGenCancelled"));
       const batch = selectedAssets.slice(i, i + batchSize);
       await Promise.allSettled(batch.map((item) => generatePrompt(item)));
     }
-    window.$message.success($t('workbench.assets.batch.promptDone'));
+    window.$message.success($t("workbench.assets.batch.promptDone"));
   } catch (e) {
-    if (e instanceof Error && e.message !== $t('workbench.assets.batch.promptGenCancelled')) {
+    if (e instanceof Error && e.message !== $t("workbench.assets.batch.promptGenCancelled")) {
       window.$message.error(e.message);
     }
   } finally {
@@ -336,83 +337,43 @@ async function generatePrompt(data: AssetItem) {
       }
     }
   } catch (e: any) {
-    window.$message.error(`"${data.name}" ${e?.message ?? $t('workbench.assets.batch.promptFail')}`);
+    window.$message.error(`"${data.name}" ${e?.message ?? $t("workbench.assets.batch.promptFail")}`);
   } finally {
     rowPromptLoading.value[data.id] = false;
   }
 }
-const imageLoading = ref(false);
-const imageGenerateCancel = ref(false);
-// 生成图片
 async function handleBatchGenerateImage() {
   const selectedAssets = tableData.value.filter((item) => selectedRowKeys.value.includes(item.id));
   if (selectedAssets.length === 0) {
-    window.$message.warning($t('workbench.assets.selectAtLeastOne'));
+    window.$message.warning($t("workbench.assets.selectAtLeastOne"));
     return;
   }
   // 检查是否所有选中的资产都有提示词
   const assetsWithoutPrompt = selectedAssets.filter((item) => !item.prompt || item.prompt.trim() === "");
   if (assetsWithoutPrompt.length > 0) {
-    window.$message.warning($t('workbench.assets.batch.missingPrompts', { count: assetsWithoutPrompt.length }));
+    window.$message.warning($t("workbench.assets.batch.missingPrompts", { count: assetsWithoutPrompt.length }));
     return;
   }
-  imageGenerateCancel.value = false;
-  imageLoading.value = true;
-  const batchSize = otherSetting.value.assetsBatchGenereateSize || 5; // 从设置中获取批量生成的大小，默认为5
   try {
-    for (let i = 0; i < selectedAssets.length; i += batchSize) {
-      if (imageGenerateCancel.value) throw new Error($t('workbench.assets.batch.promptGenCancelled'));
-      const batch = selectedAssets.slice(i, i + batchSize);
-      await Promise.allSettled(
-        batch.map((item) =>
-          startGenerate({
-            id: item.id,
-            name: item.name,
-            prompt: item.prompt,
-            type: props.type ?? "props",
-          }),
-        ),
-      );
-    }
-    window.$message.success($t('workbench.assets.batch.imageDone'));
-  } catch (e) {
-    if (e instanceof Error && e.message !== $t('workbench.assets.batch.promptGenCancelled')) {
-      window.$message.error(e.message);
-    }
-  } finally {
-    imageLoading.value = false;
-    imageGenerateCancel.value = false;
-  }
-}
-async function startGenerate(data: { id: number; prompt: string; name: string; type: string }) {
-  if (imageGenerateCancel.value) return;
-  rowImageLoading.value[data.id] = true;
-  try {
-    const res = await axios.post("/assets/generateAssets", {
-      type: data.type,
-      projectId: project.value?.id,
-      name: data.name,
-      base64: undefined,
-      prompt: data.prompt ?? "",
-      id: data.id,
-    });
-    if (!imageGenerateCancel.value) {
-      const index = tableData.value.findIndex((item: AssetItem) => item.id === res.data.assetsId);
-      if (index !== -1) {
-        tableData.value[index].filePath = res.data.path;
-        // 同步更新 localData
-        const localIndex = localData.value.findIndex((item: AssetItem) => item.id === res.data.assetsId);
-        if (localIndex !== -1) {
-          localData.value[localIndex].filePath = res.data.path;
-        }
-      }
-    }
+    const promptBundle = buildBatchPrompt(
+      selectedAssets.map((item) => ({
+        title: item.name,
+        prompt: buildManualImagePrompt({
+          name: item.name,
+          category: item.type ?? props.type,
+          prompt: item.prompt,
+          description: item.describe,
+          artStyle: project.value?.artStyle,
+          aspectRatio: project.value?.videoRatio,
+          resolution: project.value?.imageQuality,
+        }),
+      })),
+    );
+    await copyText(promptBundle);
+    window.$message.success(`已复制 ${selectedAssets.length} 条完整生图提示词，请生成后逐项上传`);
+    selectedRowKeys.value = [];
   } catch (e: any) {
-    if (!imageGenerateCancel.value) {
-      window.$message.error(`"${data.name}" ${$t('workbench.assets.batch.imageGenFail')}: ${e?.message ?? $t('workbench.assets.batch.unknownError')}`);
-    }
-  } finally {
-    rowImageLoading.value[data.id] = false;
+    window.$message.error(e?.message ?? "批量复制提示词失败");
   }
 }
 </script>

--- a/src/views/assets/components/generateImage.vue
+++ b/src/views/assets/components/generateImage.vue
@@ -46,12 +46,15 @@
               </t-loading>
             </div>
           </div>
-          <div class="selectModel f">
-            <div style="width: 60%">
-              <span style="font-size: 16px; font-weight: 900">{{ $t("workbench.assets.gen.selectModel") }}</span>
-              <modelSelect v-model="selectValue" :type="`image`" />
+          <div class="manualPrompt">
+            <div class="jb">
+              <span class="manualPromptTitle">完整生图提示词</span>
+              <t-tag theme="warning">请复制后到外部工具生成</t-tag>
             </div>
-            <div style="width: 40%; margin-left: 15px">
+            <t-textarea :value="completePrompt" readonly :autosize="{ minRows: 9, maxRows: 12 }" />
+          </div>
+          <div class="selectModel f">
+            <div style="width: 50%">
               <span style="font-size: 16px; font-weight: 900">{{ $t("workbench.assets.gen.selectResolution") }}</span>
               <t-select v-model="resolution">
                 <t-option key="1K" label="1K" value="1K" />
@@ -59,15 +62,17 @@
                 <t-option key="4K" label="4K" value="4K" />
               </t-select>
             </div>
+            <div style="width: 50%; margin-left: 15px">
+              <span style="font-size: 16px; font-weight: 900">项目画幅</span>
+              <t-input :value="project?.videoRatio || '跟随项目设置'" readonly />
+            </div>
           </div>
           <div class="generateButton" style="margin-top: 20px">
-            <t-button theme="primary" size="large" block :loading="generateLoading" @click="handleGenerate">
-              {{ $t("workbench.assets.gen.generateBtn") }}
-            </t-button>
+            <t-button theme="primary" size="large" block @click="copyManualPrompt">复制完整生图提示词</t-button>
           </div>
         </t-card>
         <t-divider layout="vertical" style="height: 700px" />
-        <t-card :title="$t('workbench.assets.gen.resultTitle')" :bordered="false" :style="{ width: '60%' }">
+        <t-card title="上传外部生成结果" :bordered="false" :style="{ width: '60%' }">
           <template #actions>
             <t-tag v-if="resultImages.length">{{ $t("workbench.assets.gen.generatedCount", { count: resultImages.length }) }}</t-tag>
           </template>
@@ -120,7 +125,10 @@
                   <div
                     class="uploadPlaceholder f ac jc"
                     style="width: 180px; height: 180px; border: 2px dashed #d9d9d9; border-radius: 20px; cursor: pointer">
-                    <i-plus theme="outline" size="24" fill="#4a4a4a" />
+                    <div class="fc ac">
+                      <i-plus theme="outline" size="24" fill="#4a4a4a" />
+                      <span style="margin-top: 8px">上传生成好的图片</span>
+                    </div>
                   </div>
                 </t-upload>
               </div>
@@ -139,10 +147,10 @@
 </template>
 
 <script setup lang="ts">
-import modelSelect from "@/components/modelSelect.vue";
 import projectStore from "@/stores/project";
 const { project } = storeToRefs(projectStore());
 import axios from "@/utils/axios";
+import { buildManualImagePrompt, copyText, fileToDataUrl } from "@/utils/manualMedia";
 const props = defineProps<{
   formData: {
     id?: number;
@@ -172,9 +180,6 @@ const referenceFileList = ref<any[]>([]);
 const autoUpload = ref(false);
 const showImageFileName = ref(false);
 const generateLoading = ref(false);
-const selectValue = ref(""); //选择的模型
-
-const value2 = ref("");
 //智能生成提示词
 const promptLoading = ref(false);
 async function generatePrompt() {
@@ -199,53 +204,29 @@ async function generatePrompt() {
 }
 const emit = defineEmits(["update"]);
 const resolution = ref("1K");
-//生成图片
-async function handleGenerate() {
+const completePrompt = computed(() =>
+  buildManualImagePrompt({
+    name: props.formData.name,
+    category: props.formData.type,
+    prompt: props.formData.prompt,
+    description: props.formData.describe,
+    artStyle: project.value?.artStyle,
+    aspectRatio: project.value?.videoRatio,
+    resolution: resolution.value,
+    referenceCount: referenceFileList.value.length,
+  }),
+);
+
+async function copyManualPrompt() {
   if (!props.formData.prompt) {
     window.$message.error($t("workbench.assets.gen.fillPrompt"));
     return;
   }
-  if (!resolution.value) {
-    window.$message.error($t("workbench.assets.gen.pickResolution"));
-    return;
-  }
-  if (!selectValue.value) {
-    window.$message.error($t("workbench.assets.gen.pickModel"));
-    return;
-  }
-  generateLoading.value = true;
   try {
-    let referenceImageBase64 = "";
-    if (referenceFileList.value.length > 0) {
-      const file = referenceFileList.value[0].raw;
-      if (file instanceof File) {
-        referenceImageBase64 = await new Promise<string>((resolve) => {
-          const reader = new FileReader();
-          reader.onload = (e) => {
-            const base64 = e.target?.result as string;
-            resolve(base64);
-          };
-          reader.readAsDataURL(file);
-        });
-      }
-    }
-    await axios.post("/assetsGenerate/generateAssets", {
-      type: props.formData.type ?? "props",
-      projectId: project.value?.id,
-      name: props.formData.name ?? $t("workbench.assets.gen.unnamed"),
-      base64: referenceImageBase64,
-      prompt: props.formData.prompt,
-      model: selectValue.value,
-      id: props.formData.id,
-      resolution: resolution.value,
-    });
-    window.$message.success($t("workbench.assets.gen.assetGenSuccess"));
-    await fetchGeneratedImages();
+    await copyText(completePrompt.value);
+    window.$message.success("完整生图提示词已复制，请在外部工具生成后上传");
   } catch (e: any) {
-    window.$message.error(e.message ?? $t("workbench.assets.gen.assetGenFail"));
-    fetchGeneratedImages();
-  } finally {
-    generateLoading.value = false;
+    window.$message.error(e.message ?? "复制提示词失败");
   }
 }
 //自定义上传图片
@@ -255,9 +236,7 @@ function handleCustomUpload(files: any[]): void {
   if (files.length > 0) {
     const file = files[0]?.raw || files[0];
     if (file instanceof File) {
-      const reader = new FileReader();
-      reader.onload = (e) => {
-        const base64 = e.target?.result as string;
+      fileToDataUrl(file).then((base64) => {
         resultImages.value.push({
           id: "",
           src: base64,
@@ -265,8 +244,7 @@ function handleCustomUpload(files: any[]): void {
         });
         window.$message.success($t("workbench.assets.gen.uploadOk"));
         customFileList.value = [];
-      };
-      reader.readAsDataURL(file);
+      });
     }
   }
 }
@@ -289,7 +267,6 @@ watch(
   (newVal) => {
     if (newVal) {
       referenceFileList.value = [];
-      value2.value = "";
       selectedImageIndex.value = null;
       hoveredImageIndex.value = null;
       generateLoading.value = false;
@@ -398,6 +375,16 @@ async function onClick() {
       margin-top: 20px;
       .input {
         margin-top: 10px;
+      }
+    }
+    .manualPrompt {
+      margin-top: 20px;
+      .manualPromptTitle {
+        font-size: 16px;
+        font-weight: 900;
+      }
+      :deep(textarea) {
+        font-family: Monaco, Menlo, Consolas, monospace;
       }
     }
     .selectModel {

--- a/src/views/assets/index.vue
+++ b/src/views/assets/index.vue
@@ -32,7 +32,7 @@
                         <span @click="batchGeneration(1)">{{ $t("workbench.assets.generatePrompt") }}</span>
                       </div>
                       <div class="generateImage">
-                        <span @click="batchGeneration(2)">{{ $t("workbench.assets.generateImage") }}</span>
+                        <span @click="batchGeneration(2)">复制完整生图提示词</span>
                       </div>
                     </div>
                   </template>
@@ -413,11 +413,14 @@
       @confirm="keep"
       @close="batchGenerationShow = false">
       <div class="batch">
-        <span>{{ $t("workbench.assets.confirmBatch", { type: batchType }) }}</span>
+        <span>
+          {{
+            batchType === $t("workbench.assets.batchGenPrompt")
+              ? $t("workbench.assets.confirmBatch", { type: batchType })
+              : "复制所选资产的完整提示词，到外部工具生成后请逐项上传。"
+          }}
+        </span>
         <t-form labelAlign="top">
-          <t-form-item :label="$t('workbench.assets.model')" name="selectValue" v-if="batchType === $t('workbench.assets.batchGenImage')">
-            <modelSelect v-model="selectValue" :type="`image`" />
-          </t-form-item>
           <t-form-item :label="$t('workbench.assets.resolution')" name="resolution" v-if="batchType === $t('workbench.assets.batchGenImage')">
             <t-select v-model="resolution" :placeholder="$t('workbench.assets.resolutionPh')">
               <t-option key="1K" label="1K" value="1K" />
@@ -433,7 +436,6 @@
 
 <script setup lang="ts">
 import dayjs from "dayjs";
-import modelSelect from "@/components/modelSelect.vue";
 import { useFileDialog } from "@vueuse/core";
 import axios from "@/utils/axios";
 import type { TabValue, TableProps } from "tdesign-vue-next";
@@ -442,6 +444,7 @@ import addAudioAssets from "./components/addAudioAssets.vue";
 import generateImage from "./components/generateImage.vue";
 import projectStore from "@/stores/project";
 import settingStore from "@/stores/setting";
+import { buildBatchPrompt, buildManualImagePrompt, copyText } from "@/utils/manualMedia";
 const { otherSetting } = storeToRefs(settingStore());
 
 const props = withDefaults(
@@ -663,7 +666,6 @@ async function handleAdd(type: string) {
   }
 }
 const batchGenerationShow = ref(false);
-const selectValue = ref(""); //选择的模型
 const resolution = ref("1K"); //选择的分辨率
 const batchType = ref("");
 function batchGeneration(type: number) {
@@ -738,10 +740,6 @@ async function handleBatchGenerateImage() {
     window.$message.warning($t("workbench.assets.selectAtLeastOne"));
     return;
   }
-  if (!selectValue.value) {
-    window.$message.error($t("workbench.assets.selectModel"));
-    return;
-  }
   if (!resolution.value) {
     window.$message.error($t("workbench.assets.selectResolution"));
     return;
@@ -757,50 +755,29 @@ async function handleBatchGenerateImage() {
   });
   if (validAssets.length === 0) return;
 
-  // 设置 state 为 '生成中'，让轮询自动接管状态跟踪
-  const validParentAssets = validAssets.filter((a) => selectedRowKeys.value.includes(a.id));
-  const validSubAssets = validAssets.filter((a) => selectedSubRowKeys.value.includes(a.id));
-  validParentAssets.forEach((asset) => {
-    const target = tableData.value.find((row) => row.id === asset.id);
-    if (target) target.state = "生成中";
-  });
-  validSubAssets.forEach((asset) => {
-    tableData.value.forEach((row) => {
-      const target = row.sonAssets?.find((sub) => sub.id === asset.id);
-      if (target) target.state = "生成中";
-    });
-  });
   selectedRowKeys.value = selectedRowKeys.value.filter((key) => !validAssets.some((a) => a.id === key));
   selectedSubRowKeys.value = selectedSubRowKeys.value.filter((key) => !validAssets.some((a) => a.id === key));
   batchGenerationShow.value = false;
 
   try {
-    await axios.post("/assetsGenerate/batchGenerateImageAssets", {
-      projectId: project.value?.id,
-      model: selectValue.value,
-      resolution: resolution.value,
-      concurrentCount: otherSetting.value.assetsBatchGenereateSize,
-      items: validAssets.map((item) => ({
-        id: item.id,
-        type: item.type ?? "props",
-        name: item.name ?? $t("workbench.cornerScape.unnamed"),
-        prompt: item.prompt || item.describe,
+    const promptBundle = buildBatchPrompt(
+      validAssets.map((item) => ({
+        title: item.name ?? $t("workbench.cornerScape.unnamed"),
+        prompt: buildManualImagePrompt({
+          name: item.name,
+          category: item.type ?? "props",
+          prompt: item.prompt || item.describe,
+          description: item.describe,
+          artStyle: project.value?.artStyle,
+          aspectRatio: project.value?.videoRatio,
+          resolution: resolution.value,
+        }),
       })),
-    });
+    );
+    await copyText(promptBundle);
+    window.$message.success(`已复制 ${validAssets.length} 条完整生图提示词，请生成后逐项上传`);
   } catch (e: any) {
-    window.$message.error($t("workbench.assets.imageGenFail", { name: "", error: e.message ?? "" }));
-    validAssets.forEach((asset) => {
-      // 在父级和子级中都查找
-      const parentTarget = tableData.value.find((row) => row.id === asset.id);
-      if (parentTarget) {
-        parentTarget.state = "生成失败";
-      } else {
-        tableData.value.forEach((row) => {
-          const subTarget = row.sonAssets?.find((sub) => sub.id === asset.id);
-          if (subTarget) subTarget.state = "生成失败";
-        });
-      }
-    });
+    window.$message.error(e.message ?? "批量复制提示词失败");
   }
 }
 // 批量删除

--- a/src/views/cornerScape/index.vue
+++ b/src/views/cornerScape/index.vue
@@ -31,9 +31,6 @@
             <t-checkbox-group @change="onChangeFn" v-model="checkboxValue" :options="translatedOptions" class="filterGroup" />
           </t-form-item>
 
-          <t-form-item :label="$t('workbench.cornerScape.genModel')">
-            <modelSelect v-model="selectValue" :type="`image`" />
-          </t-form-item>
           <t-form-item :label="$t('workbench.cornerScape.resolution')">
             <t-select
               v-model="resolution"
@@ -60,9 +57,7 @@
                   {{ $t("workbench.cornerScape.batchBingAudio") }}
                 </t-button>
               </div>
-              <t-button theme="primary" block @click="batchGenerationImage">
-                {{ $t("workbench.cornerScape.startBatch") }}
-              </t-button>
+              <t-button theme="primary" block @click="batchGenerationImage">批量复制完整生图提示词</t-button>
             </div>
           </t-form-item>
         </t-form>
@@ -189,9 +184,6 @@
               </div>
             </div>
           </t-form-item>
-          <t-form-item :label="$t('workbench.cornerScape.genModel')">
-            <modelSelect v-model="selectValue" :type="`image`" />
-          </t-form-item>
           <t-form-item :label="$t('workbench.cornerScape.resolution')">
             <t-select v-model="editForm.resolution" :placeholder="$t('workbench.cornerScape.resolutionPh')" :options="resolutionOptions" />
           </t-form-item>
@@ -232,9 +224,13 @@
                 <template #icon><t-icon name="edit" /></template>
                 {{ $t("workbench.cornerScape.aiPolish") }}
               </t-button>
-              <t-button theme="primary" @click="regenerateItem" :disabled="currentItem.state == '生成中' ? true : false">
-                <template #icon><t-icon name="refresh" /></template>
-                {{ $t("workbench.cornerScape.regenerate") }}
+              <t-button theme="primary" @click="copyManualPrompt">
+                <template #icon><t-icon name="file-copy" /></template>
+                复制完整生图提示词
+              </t-button>
+              <t-button theme="success" variant="outline" :loading="uploadingManualImage" @click="uploadManualImage">
+                <template #icon><t-icon name="upload" /></template>
+                上传生成图片
               </t-button>
             </div>
           </t-form-item>
@@ -247,9 +243,10 @@
 <script setup lang="ts">
 import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
-import modelSelect from "@/components/modelSelect.vue";
 import settingStore from "@/stores/setting";
 import openAssetsSelector from "@/utils/assetsCheck";
+import { buildBatchPrompt, buildManualImagePrompt, copyText, fileToDataUrl } from "@/utils/manualMedia";
+import { useFileDialog } from "@vueuse/core";
 
 const { otherSetting } = storeToRefs(settingStore());
 interface Image {
@@ -277,7 +274,6 @@ interface DataItem {
 
 const checkboxValue = ref<string[]>([]);
 const { project } = storeToRefs(projectStore());
-const selectValue = ref(project.value?.imageModel ?? "");
 const resolution = ref("1K");
 const otherTextPrompt = ref("");
 const resolutionOptions = [
@@ -300,24 +296,11 @@ const translatedOptions = computed(() =>
 const dataList = ref<DataItem[]>([]);
 const loading = ref(false);
 
-// 用于取消进行中的生成请求
-let abortController: AbortController | null = null;
-
-function createAbortController() {
-  abortController?.abort();
-  abortController = new AbortController();
-  return abortController;
-}
-
 onMounted(() => {
   getFilteredData();
 });
 
 onUnmounted(() => {
-  if (abortController) {
-    abortController.abort();
-    abortController = null;
-  }
   stopPolling();
   stopImagePolling();
   stopAudioPolling();
@@ -520,12 +503,8 @@ function setItemState(id: number, state: string) {
   if (currentItem.value?.id === id) currentItem.value.state = state;
 }
 
-function regenerateItem() {
+async function copyManualPrompt() {
   if (!currentItem.value) return;
-  if (!selectValue.value) {
-    window.$message.warning($t("workbench.cornerScape.msg.selectModel"));
-    return;
-  }
   if (!editForm.resolution) {
     window.$message.warning($t("workbench.cornerScape.msg.selectResolution"));
     return;
@@ -534,35 +513,58 @@ function regenerateItem() {
     window.$message.warning($t("workbench.cornerScape.msg.enterPrompt"));
     return;
   }
-  const item = currentItem.value;
-  setItemState(item.id, "生成中");
-  drawerVisible.value = false;
-  const controller = createAbortController();
-  axios
-    .post(
-      "/assetsGenerate/generateAssets",
-      {
-        type: item.type ?? "props",
-        projectId: project.value?.id,
-        name: item.name ?? $t("workbench.cornerScape.unnamed"),
-        base64: "",
-        prompt: editForm.prompt,
-        model: selectValue.value,
-        id: item.id,
-        resolution: editForm.resolution,
-        concurrentCount: 1,
-      },
-      { signal: controller.signal },
-    )
-    .then(async () => {
-      window.$message.success($t("workbench.cornerScape.msg.genSuccess", { name: item.name }));
-      await getFilteredData();
-    })
-    .catch((e: any) => {
-      if (e.name === "CanceledError" || e.code === "ERR_CANCELED") return;
-      window.$message.error(e.message ?? $t("workbench.cornerScape.msg.genFailed", { name: item.name }));
-      setItemState(item.id, "生成失败");
+  await copyText(
+    buildManualImagePrompt({
+      category: currentItem.value.type,
+      name: currentItem.value.name,
+      prompt: editForm.prompt,
+      description: currentItem.value.describe,
+      artStyle: project.value?.artStyle,
+      aspectRatio: project.value?.videoRatio,
+      resolution: editForm.resolution,
+    }),
+  );
+  window.$message.success("完整生图提示词已复制，请在外部工具生成后回到此处上传");
+}
+
+const uploadingManualImage = ref(false);
+const {
+  open: openManualImage,
+  onChange: onManualImageChange,
+  onCancel: onManualImageCancel,
+} = useFileDialog({
+  multiple: false,
+  reset: true,
+  accept: ".png,.jpg,.jpeg,.webp",
+});
+
+async function uploadManualImage() {
+  if (!currentItem.value) return;
+  const files = await new Promise<FileList | null>((resolve) => {
+    openManualImage();
+    onManualImageChange((value) => resolve(value));
+    onManualImageCancel(() => resolve(null));
+  });
+  if (!files?.length) return;
+
+  uploadingManualImage.value = true;
+  try {
+    await axios.post("/assets/saveAssets", {
+      id: currentItem.value.id,
+      type: currentItem.value.type,
+      projectId: project.value?.id,
+      prompt: editForm.prompt,
+      base64: await fileToDataUrl(files[0]),
     });
+    await getFilteredData();
+    const freshItem = dataList.value.find((item) => item.id === currentItem.value?.id);
+    if (freshItem) currentItem.value = freshItem;
+    window.$message.success("图片上传成功，已替换当前资产图片");
+  } catch (e: any) {
+    window.$message.error(e?.message ?? "图片上传失败");
+  } finally {
+    uploadingManualImage.value = false;
+  }
 }
 
 // 提示词失焦保存
@@ -690,10 +692,6 @@ async function batchGenerationImage() {
     window.$message.warning($t("workbench.cornerScape.msg.selectAtLeastOne"));
     return;
   }
-  if (!selectValue.value) {
-    window.$message.warning($t("workbench.cornerScape.msg.selectModel"));
-    return;
-  }
   if (!resolution.value) {
     window.$message.warning($t("workbench.cornerScape.msg.selectResolution"));
     return;
@@ -712,30 +710,27 @@ async function batchGenerationImage() {
     return;
   }
 
-  // 前端先将所有选中项标记为"生成中"
-  items.forEach((item) => setItemState(item.id, "生成中"));
-
-  window.$message.success(
-    $t("workbench.cornerScape.msg.batchStarted", { count: items.length, concurrent: otherSetting.value.assetsBatchGenereateSize }),
-  );
-
   try {
-    await axios.post("/assetsGenerate/batchGenerateImageAssets", {
-      projectId: project.value?.id,
-      model: selectValue.value,
-      resolution: resolution.value,
-      concurrentCount: otherSetting.value.assetsBatchGenereateSize,
-      items: items.map((item) => ({
-        id: item.id,
-        type: item.type ?? "props",
-        name: item.name ?? $t("workbench.cornerScape.unnamed"),
-        prompt: item.prompt,
-      })),
-    });
+    await copyText(
+      buildBatchPrompt(
+        items.map((item) => ({
+          title: item.name ?? $t("workbench.cornerScape.unnamed"),
+          prompt: buildManualImagePrompt({
+            category: item.type,
+            name: item.name,
+            prompt: item.prompt,
+            description: item.describe,
+            artStyle: project.value?.artStyle,
+            aspectRatio: project.value?.videoRatio,
+            resolution: resolution.value,
+          }),
+        })),
+      ),
+    );
     selectedIds.value = [];
+    window.$message.success(`已复制 ${items.length} 条完整生图提示词，请在外部生成后逐项上传`);
   } catch (e: any) {
-    if (e.name === "CanceledError" || e.code === "ERR_CANCELED") return;
-    window.$message.error(e.message ?? $t("workbench.cornerScape.msg.batchFailed"));
+    window.$message.error(e?.message ?? "复制完整生图提示词失败");
   }
 }
 //轮询

--- a/src/views/production/components/editImage/generatedNode.vue
+++ b/src/views/production/components/editImage/generatedNode.vue
@@ -44,7 +44,6 @@
       </div>
       <div class="operate ac jb">
         <div class="ac">
-          <modelSelect v-model="data.model" type="image" size="small" />
           <t-select v-model="data.ratio" class="paramSelect ml-5" size="small" :placeholder="$t('workbench.production.editImage.ratio')">
             <t-option value="16:9" label="16:9" />
             <t-option value="9:16" label="9:16" />
@@ -58,9 +57,9 @@
         </div>
 
         <div class="f" style="gap: 5px; margin-left: 5px">
-          <t-popup :content="$t('workbench.production.editImage.generateBtn')">
-            <t-button theme="primary" size="small" class="generateBtn" :disabled="generating" :loading="generating" @click="handleGenerate">
-              <template #icon><i-arrow-up /></template>
+          <t-popup content="复制完整生图提示词">
+            <t-button theme="primary" size="small" class="generateBtn" @click="copyManualPrompt">
+              <template #icon><t-icon name="file-copy" /></template>
             </t-button>
           </t-popup>
           <t-popup :content="$t('workbench.production.save')">
@@ -78,7 +77,6 @@
 <script setup lang="ts">
 import { Handle, useVueFlow, Position } from "@vue-flow/core";
 import type { Ref } from "vue";
-import modelSelect from "@/components/modelSelect.vue";
 import PromptEditor from "@/components/promptEditor.vue";
 import axios from "@/utils/axios";
 import { type GeneratedNodeData } from "../../utils/editImageType";
@@ -87,6 +85,7 @@ import type { Storyboard } from "../../utils/flowBuilder";
 import openAssetsSelector from "@/utils/assetsCheck";
 import { useFileDialog } from "@vueuse/core";
 import projectStore from "@/stores/project";
+import { buildManualImagePrompt, copyText } from "@/utils/manualMedia";
 const { project } = storeToRefs(projectStore());
 const openStoryboardCheck = inject<() => Promise<Storyboard[]>>("openStoryboardCheck")!;
 const { open, onChange, onCancel } = useFileDialog({ multiple: false, reset: true, accept: ".png,.jpg,.jpeg" });
@@ -171,26 +170,25 @@ async function getStoryboardImage() {
     props.data.generatedImage = filePath;
   }
 }
-// 生成
-async function handleGenerate() {
-  if (!props.data.model) return window.$message.error($t("workbench.production.editImage.selectModel"));
+async function copyManualPrompt() {
   if (!props.data.quality) return window.$message.error($t("workbench.production.editImage.selectQuality"));
   if (!props.data.ratio) return window.$message.error($t("workbench.production.editImage.selectRatio"));
-  generating.value = true;
+  if (!props.data.prompt?.trim()) return window.$message.error("请先填写图片提示词");
   try {
-    const { data } = await axios.post("/production/editImage/generateFlowImage", {
-      references: props.data.references.map((i) => i.image).filter(Boolean),
-      model: props.data.model,
-      quality: props.data.quality,
-      ratio: props.data.ratio,
-      prompt: props.data.prompt,
-      projectId: props.projectId,
-    });
-    props.data.generatedImage = data.url;
+    await copyText(
+      buildManualImagePrompt({
+        category: "storyboard",
+        name: "当前分镜图片",
+        prompt: props.data.prompt,
+        artStyle: project.value?.artStyle,
+        aspectRatio: props.data.ratio,
+        resolution: props.data.quality,
+        referenceCount: props.data.references.filter((item) => item.image).length,
+      }),
+    );
+    window.$message.success("完整生图提示词已复制，请在外部工具生成后使用左侧“上传”入口导入");
   } catch (e) {
-    return window.$message.error((e as any)?.message || $t("workbench.production.editImage.generateFailed"));
-  } finally {
-    generating.value = false;
+    return window.$message.error((e as any)?.message || "复制完整生图提示词失败");
   }
 }
 

--- a/src/views/production/components/workbench/generate/components/track.vue
+++ b/src/views/production/components/workbench/generate/components/track.vue
@@ -11,9 +11,7 @@
           <t-button size="small" variant="outline" @click="batchGenText" :loading="generateTextLoad">
             {{ $t("workbench.generate.batchGenerateText") }}
           </t-button>
-          <t-button size="small" variant="outline" @click="batchGenVideo" :loading="generateVideoLoad">
-            {{ $t("workbench.generate.batchGenerateVideo") }}
-          </t-button>
+          <t-button size="small" variant="outline" @click="batchGenVideo" :loading="generateVideoLoad">批量复制完整视频提示词</t-button>
           <!-- <t-button size="small" variant="outline" @click="importVideo">{{ $t("workbench.generate.importVideo") }}</t-button> -->
         </div>
       </div>
@@ -75,6 +73,7 @@ import projectStore from "@/stores/project";
 import imageListCacheStore from "@/stores/imageListCache";
 import JSZip from "jszip";
 import settingStore from "@/stores/setting";
+import { buildBatchPrompt, buildManualVideoPrompt, copyText } from "@/utils/manualMedia";
 
 const { otherSetting } = storeToRefs(settingStore());
 const { project } = storeToRefs(projectStore());
@@ -301,60 +300,46 @@ function getTrackUploadInfo(track: TrackItem, filterEmpty = false) {
 }
 const generateVideoLoad = ref(false);
 /** 批量为已勾选轨道生成视频 */
-function batchGenVideo() {
-  const dlg = DialogPlugin.confirm({
-    header: $t("workbench.generate.generateConfirm"),
-    body: $t("workbench.generate.generateVideosInBatches"),
-    onConfirm: async () => {
-      dlg.destroy();
+async function batchGenVideo() {
+  const checkedTrackData = trackList.value.filter((track) => checkedTrackIds.value.includes(track.id));
+  if (!checkedTrackData.length) return window.$message.warning("请先勾选视频轨道");
+  const notHasPrompt = checkedTrackData.filter((item) => !item.prompt?.trim());
+  if (notHasPrompt.length) return window.$message.warning($t("workbench.generate.skipDataWithEmptyVideoPromptWords"));
 
-      const checkedTrackData = trackList.value.filter((track) => checkedTrackIds.value.includes(track.id));
-      const notHasPrompt = checkedTrackData.filter((i) => !i.prompt);
-      if (notHasPrompt.length) return window.$message.warning($t("workbench.generate.skipDataWithEmptyVideoPromptWords"));
-
-      const trackData = checkedTrackData.map((track) => {
-        const trackId = track.id;
-        const uploadData = props.modelParmas.mode === "text" ? [] : getTrackUploadInfo(track, true);
-        return {
-          duration: props.clampDuration(track.duration || props.modelParmas.duration),
-          prompt: track.prompt,
-          uploadData,
-          trackId,
-        };
-      });
-      const requestData = {
-        projectId: project.value?.id,
-        scriptId: episodesId.value,
-        model: props.modelParmas.model,
-        mode: props.modelParmas.mode,
-        resolution: props.modelParmas.resolution,
-        audio: Boolean(props.modelParmas.audio),
-        trackData,
-      };
-      try {
-        const { data } = await axios.post("/production/workbench/batchGenerateVideo", requestData);
-        const videoRecordId: Record<number, number> = {};
-        data.forEach((item: { videoId: number; trackId: number }) => {
-          videoRecordId[item.trackId] = item.videoId;
-        });
-        checkedTrackData.forEach((i) => {
-          if (videoRecordId[i.id])
-            i.videoList.push({
-              id: videoRecordId[i.id],
-              state: "生成中",
-              src: "",
-            });
-        });
-        checkedTrackIds.value = [];
-        window.$message.success($t("workbench.generate.generateStarted"));
-      } catch (e) {
-        window.$message.error((e as any)?.message ?? $t("workbench.generate.generateError"));
-      } finally {
-        generateVideoLoad.value = false;
-      }
-    },
-    onCancel: () => dlg.destroy(),
-  });
+  generateVideoLoad.value = true;
+  try {
+    await copyText(
+      buildBatchPrompt(
+        checkedTrackData.map((track) => ({
+          title: `视频轨道 ${trackList.value.indexOf(track) + 1}`,
+          prompt: buildManualVideoPrompt({
+            name: `视频轨道 ${trackList.value.indexOf(track) + 1}`,
+            prompt: track.prompt,
+            duration: props.clampDuration(track.duration || props.modelParmas.duration),
+            aspectRatio: project.value?.videoRatio,
+            resolution: props.modelParmas.resolution,
+            mode: props.modelParmas.mode,
+            audio: Boolean(props.modelParmas.audio),
+            references: (track.id === trackList.value[activeTrackIndex.value]?.id ? props.imageList : track.medias)
+              .filter((item) => Boolean(item.src))
+              .map((item) => ({
+                fileType: item.fileType,
+                name: item.prompt,
+                prompt: item.prompt,
+                sources: item.sources,
+              })),
+          }),
+        })),
+      ),
+    );
+    checkedTrackIds.value = [];
+    checkAll.value = false;
+    window.$message.success(`已复制 ${checkedTrackData.length} 条完整视频提示词，请在外部生成后逐轨上传`);
+  } catch (e) {
+    window.$message.error((e as any)?.message ?? "复制完整视频提示词失败");
+  } finally {
+    generateVideoLoad.value = false;
+  }
 }
 
 /** 全选 / 取消全选轨道 */

--- a/src/views/production/components/workbench/generate/components/video.vue
+++ b/src/views/production/components/workbench/generate/components/video.vue
@@ -1,7 +1,10 @@
 <template>
   <t-card :title="'#' + (activeTrackIndex + 1) + $t('workbench.generate.videoMenu')" header-bordered style="height: 100%">
     <template #actions>
-      <t-button size="small" :loading="generating" @click="emit('generate')">{{ $t("workbench.generate.generate") }}</t-button>
+      <t-space>
+        <t-button size="small" @click="emit('generate')">复制完整视频提示词</t-button>
+        <t-button size="small" theme="success" variant="outline" :loading="uploadingVideo" @click="uploadVideo">上传生成视频</t-button>
+      </t-space>
     </template>
     <div class="history">
       <div class="titleBox f ac">
@@ -81,6 +84,8 @@
 import type { Ref } from "vue";
 import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
+import { useFileDialog } from "@vueuse/core";
+import { fileToDataUrl } from "@/utils/manualMedia";
 
 const props = defineProps<{
   activeTrackIndex: number;
@@ -101,6 +106,42 @@ const selectVideoId = ref();
 const videoCoverMap = ref<Record<string, string>>({});
 const videoPlayerVisible = ref(false);
 const playingVideoSrc = ref<string>();
+const uploadingVideo = ref(false);
+const {
+  open: openVideoFile,
+  onChange: onVideoFileChange,
+  onCancel: onVideoFileCancel,
+} = useFileDialog({
+  multiple: false,
+  reset: true,
+  accept: ".mp4,.webm,.mov,.mkv",
+});
+
+async function uploadVideo() {
+  if (!currentTrack.value?.id) return window.$message.warning("当前视频轨道不可用");
+  const files = await new Promise<FileList | null>((resolve) => {
+    openVideoFile();
+    onVideoFileChange((value) => resolve(value));
+    onVideoFileCancel(() => resolve(null));
+  });
+  if (!files?.length) return;
+
+  uploadingVideo.value = true;
+  try {
+    await axios.post("/production/workbench/uploadVideo", {
+      projectId: project.value?.id,
+      scriptId: episodesId.value,
+      trackId: currentTrack.value.id,
+      base64Data: await fileToDataUrl(files[0]),
+    });
+    window.$message.success("视频上传成功，已添加并选中为当前轨道视频");
+    emit("refresh");
+  } catch (e) {
+    window.$message.error((e as any)?.message ?? "视频上传失败");
+  } finally {
+    uploadingVideo.value = false;
+  }
+}
 
 /** 选中历史视频并同步到后端 */
 async function selectVideo(v: HistoryVideoItem) {

--- a/src/views/production/components/workbench/generate/index.vue
+++ b/src/views/production/components/workbench/generate/index.vue
@@ -56,6 +56,7 @@ import axios from "@/utils/axios";
 import projectStore from "@/stores/project";
 import promptEditor from "@/components/promptEditor.vue";
 import imageListCacheStore from "@/stores/imageListCache";
+import { buildManualVideoPrompt, copyText } from "@/utils/manualMedia";
 
 const { project } = storeToRefs(projectStore());
 const episodesId = inject<Ref<number>>("episodesId")!;
@@ -385,53 +386,31 @@ onMounted(() => {
 });
 /** 单个轨道生成视频 */
 async function generateVideo() {
-  const dlg = DialogPlugin.confirm({
-    header: $t("workbench.generate.generateConfirm"),
-    body: $t("workbench.generate.generateConfirmBody"),
-    onConfirm: async () => {
-      dlg.destroy();
-      try {
-        const { data } = await axios.post("/production/workbench/generateVideo", {
-          projectId: project.value?.id,
-          scriptId: episodesId.value,
-          uploadData:
-            modelParmas.value.mode === "text"
-              ? []
-              : (() => {
-                  const frameMode = ["startEndRequired", "endFrameOptional", "startFrameOptional"];
-                  const preSliced = frameMode.includes(modelParmas.value.mode)
-                    ? imageList.value.slice(0, 2)
-                    : modelParmas.value.mode === "singleImage"
-                      ? imageList.value.slice(0, 1)
-                      : imageList.value;
-                  const filtered = preSliced
-                    .filter((item) => Boolean(item.src) && typeof item.id === "number" && !isNaN(item.id))
-                    .map(({ id, sources }) => ({ id, sources }));
-                  if (frameMode.includes(modelParmas.value.mode)) return filtered.slice(0, 2);
-                  if (modelParmas.value.mode === "singleImage") return filtered.slice(0, 1);
-                  return filtered;
-                })(),
-          prompt: currentTrack.value.prompt,
-          model: modelParmas.value.model,
-          mode: modelParmas.value.mode,
-          resolution: modelParmas.value.resolution,
-          duration: modelParmas.value.duration,
-          audio: modelParmas.value.audio,
-          trackId: currentTrack.value.id,
-        });
-        window.$message.success($t("workbench.generate.generateStarted"));
-        currentTrack.value.videoList.push({
-          id: data,
-          state: "生成中",
-          src: "",
-        });
-      } catch (e) {
-        window.$message.error((e as any)?.message ?? "视频发起生成请求失败");
-      } finally {
-      }
-    },
-    onCancel: () => dlg.destroy(),
-  });
+  if (!currentTrack.value?.prompt?.trim()) return window.$message.warning("请先填写视频提示词");
+  try {
+    await copyText(
+      buildManualVideoPrompt({
+        name: `视频轨道 ${activeTrackIndex.value + 1}`,
+        prompt: currentTrack.value.prompt,
+        duration: modelParmas.value.duration,
+        aspectRatio: project.value?.videoRatio,
+        resolution: modelParmas.value.resolution,
+        mode: modelParmas.value.mode,
+        audio: modelParmas.value.audio,
+        references: imageList.value
+          .filter((item) => Boolean(item.src))
+          .map((item) => ({
+            fileType: item.fileType,
+            name: item.prompt,
+            prompt: item.prompt,
+            sources: item.sources,
+          })),
+      }),
+    );
+    window.$message.success("完整视频提示词已复制，请在外部工具生成后回到视频区域上传");
+  } catch (e) {
+    window.$message.error((e as any)?.message ?? "复制完整视频提示词失败");
+  }
 }
 let pollTimer: NodeJS.Timeout | null = null;
 let promptPollTimer: NodeJS.Timeout | null = null;

--- a/src/views/production/node/storyboard.vue
+++ b/src/views/production/node/storyboard.vue
@@ -99,7 +99,7 @@
       <div class="ac" style="gap: 10px">
         <t-button block @click="previewAll" :disabled="!storyboard.length">{{ $t("workbench.production.node.storyboard.gridPreview") }}</t-button>
         <t-button block @click="batchGenerateImage" :disabled="!storyboard.length || !selectedIds.length" :loading="generateLoading">
-          {{ $t("workbench.production.node.storyboard.generateImage") }}
+          复制所选分镜完整生图提示词
         </t-button>
 
         <!-- <t-button block @click="batchGenerateImage" :disabled="!storyboard.length" :loading="generateLoading">
@@ -127,6 +127,7 @@ import axios from "@/utils/axios";
 import type { AssetItem, Storyboard } from "../utils/flowBuilder";
 import projectStore from "@/stores/project";
 import productionAgentStore from "@/stores/productionAgent";
+import { buildBatchPrompt, buildManualImagePrompt, copyText } from "@/utils/manualMedia";
 const { project } = storeToRefs(projectStore());
 const { episodesId } = storeToRefs(productionAgentStore());
 
@@ -262,11 +263,30 @@ async function batchGenerateImage() {
   if (!selectedIds.value.length) return window.$message.warning("请先选择分镜面板");
   generateLoading.value = true;
   try {
-    await productionAgentStore().batchGenerateStoryboard(selectedIds.value, true);
-    window.$message.success($t("workbench.production.node.storyboard.batchGenerateSuccess"));
+    const selectedStoryboards = storyboard.value.filter((item) => item.id != null && selectedIds.value.includes(item.id));
+    const emptyPrompts = selectedStoryboards.filter((item) => !item.prompt?.trim());
+    if (emptyPrompts.length) return window.$message.warning("所选分镜中存在空提示词，请先补充提示词");
+
+    await copyText(
+      buildBatchPrompt(
+        selectedStoryboards.map((item, index) => ({
+          title: `分镜 ${storyboard.value.indexOf(item) + 1 || index + 1}`,
+          prompt: buildManualImagePrompt({
+            category: "storyboard",
+            name: `分镜 ${storyboard.value.indexOf(item) + 1 || index + 1}`,
+            prompt: [item.prompt, item.videoDesc].filter(Boolean).join("\n"),
+            artStyle: project.value?.artStyle,
+            aspectRatio: project.value?.videoRatio,
+            resolution: project.value?.imageQuality,
+            referenceCount: item.associateAssetsIds?.length ?? 0,
+          }),
+        })),
+      ),
+    );
+    window.$message.success(`已复制 ${selectedStoryboards.length} 条完整分镜生图提示词，请在外部生成后点击对应分镜上传`);
     selectedIds.value = [];
-  } catch (e) {
-    window.$message.error($t("workbench.production.node.storyboard.batchGenerateFailed"));
+  } catch (e: any) {
+    window.$message.error(e?.message ?? "复制分镜提示词失败");
   } finally {
     generateLoading.value = false;
   }

--- a/src/views/project/components/projectDialog.vue
+++ b/src/views/project/components/projectDialog.vue
@@ -25,24 +25,6 @@
             <t-form-item :label="$t('workbench.project.dialog.novelType')">
               <t-input v-model="formState.type" :placeholder="$t('workbench.project.dialog.novelTypePh')" />
             </t-form-item>
-            <t-form-item :label="$t('workbench.project.dialog.modelData')">
-              <div class="ac" style="gap: 5px; width: 100%">
-                <modelSelect v-model="formState.imageModel" type="image" />
-                <t-select v-model="formState.imageQuality" class="paramSelect ml-5" :placeholder="$t('workbench.production.editImage.quality')">
-                  <t-option value="1K" label="1K" />
-                  <t-option value="2K" label="2K" />
-                  <t-option value="4K" label="4K" />
-                </t-select>
-              </div>
-            </t-form-item>
-            <t-form-item :label="$t('workbench.project.dialog.videoModelData')">
-              <div class="ac" style="gap: 5px; width: 100%">
-                <modelSelect v-model="formState.videoModel" type="video" @change="changeFn" :changeConfig="true" />
-                <t-select v-model="formState.mode" class="paramSelect ml-5" :placeholder="$t('workbench.production.editImage.mode')">
-                  <t-option v-for="value in mode" :key="value.value" :value="value.value" :label="value.label" />
-                </t-select>
-              </div>
-            </t-form-item>
             <t-form-item :label="$t('workbench.project.dialog.videoRatio')">
               <t-select v-model="formState.videoRatio" :options="RATIO_OPTIONS" />
             </t-form-item>
@@ -287,7 +269,6 @@ import { MdEditor } from "md-editor-v3";
 import settingStore from "@/stores/setting";
 const { themeSetting } = storeToRefs(settingStore());
 import type { ToolbarNames } from "md-editor-v3";
-import modelSelect from "@/components/modelSelect.vue";
 import type { TabValue } from "tdesign-vue-next";
 import { DialogPlugin } from "tdesign-vue-next";
 
@@ -421,14 +402,10 @@ function handleCancel() {
 function handleOk() {
   if (!formState.value.name) return window.$message.warning($t("workbench.project.msg.enterProjectName"));
   if (!formState.value.type) return window.$message.warning($t("workbench.project.msg.enterProjectType"));
-  if (!formState.value.imageModel) return window.$message.warning($t("workbench.project.msg.enterImageModel"));
-  if (!formState.value.videoModel) return window.$message.warning($t("workbench.project.msg.enterVideoModel"));
   if (!formState.value.artStyle) return window.$message.warning($t("workbench.project.msg.enterArtStyle"));
   if (!formState.value.directorManual) return window.$message.warning($t("workbench.project.msg.directorManual"));
   if (!formState.value.videoRatio) return window.$message.warning($t("workbench.project.msg.enterVideoRatio"));
   if (!formState.value.intro) return window.$message.warning($t("workbench.project.msg.enterProjectIntro"));
-  if (!formState.value.imageQuality) return window.$message.warning($t("workbench.project.msg.enterProjectQuality"));
-  if (!formState.value.mode) return window.$message.warning($t("workbench.project.msg.selectMode"));
   if (isEdit.value) {
     emit("edit", {
       id: formState.value.id as unknown as string,
@@ -497,22 +474,6 @@ watch(addProjectShow, async (visible) => {
         mode: props.projectData.mode || "text",
         directorManual: props.projectData.directorManual || "",
       };
-      // 编辑模式下主动获取视频模型详情，填充 mode 列表以回显 label
-      if (props.projectData.videoModel) {
-        try {
-          const { data } = await axios.post("/modelSelect/getModelDetail", {
-            modelId: props.projectData.videoModel,
-          });
-          if (data?.mode) {
-            mode.value = data.mode.map((item: any) => ({
-              label: getModeLabel(item),
-              value: modeToKey(item),
-            }));
-          }
-        } catch (e) {
-          // 获取失败不影响其他功能
-        }
-      }
     } else {
       resetForm();
     }
@@ -664,41 +625,6 @@ function deleteVisualManual(item: VisualManualItem) {
         });
     },
   });
-}
-type VideoMode =
-  | "singleImage" //单图参考
-  | "startEndRequired" //首尾帧（两张都得有）
-  | "endFrameOptional" //首尾帧（尾帧可选）
-  | "startFrameOptional" //首尾帧（首帧可选）
-  | "text" //文本
-  | (`videoReference:${number}` | `imageReference:${number}` | `audioReference:${number}`)[]; //多参考（数字代表限制数量）
-const mode = ref<{ label: string; value: string }[]>([]);
-const MODE_LABEL: Record<string, string> = {
-  singleImage: $t("workbench.production.generate.modeSingleImage"),
-  startEndRequired: $t("workbench.production.generate.modeStartEnd"),
-  endFrameOptional: $t("workbench.production.generate.modeStartEnd"),
-  startFrameOptional: $t("workbench.production.generate.modeStartEnd"),
-  text: $t("workbench.production.generate.modeText"),
-  videoReference: $t("workbench.production.generate.modeVideoRef"),
-  imageReference: $t("workbench.production.generate.modeImageRef"),
-  audioReference: $t("workbench.production.generate.modeAudioRef"),
-};
-// 模式转换为统一的 key 形式，方便后续处理
-function getModeLabel(mode?: VideoMode): string {
-  if (!mode) return "";
-  if (Array.isArray(mode)) return mode.map((r) => MODE_LABEL[r.replace(/:.*$/, "")] ?? r).join("、");
-  return MODE_LABEL[mode] ?? mode;
-}
-//模式数组转换为字符串 key，方便在前端使用和比较
-function modeToKey(m: VideoMode): string {
-  return Array.isArray(m) ? JSON.stringify(m) : m;
-}
-//获取模式
-function changeFn(val: string, data: any) {
-  mode.value = data.mode.map((item: any) => ({
-    label: getModeLabel(item),
-    value: modeToKey(item),
-  }));
 }
 //导演手册
 interface DirectorManualItem {

--- a/src/views/project/index.vue
+++ b/src/views/project/index.vue
@@ -94,27 +94,6 @@ async function openProject(projectId: string | undefined) {
 
   if (!item) return window.$message.error($t("workbench.project.msg.notFound"));
 
-  if (!item.imageModel || !item.videoModel) {
-    window.$message.warning($t("workbench.project.msg.modelProviderDisabled"));
-    return openEdit(item);
-  }
-
-  try {
-    if (item.imageModel) {
-      await axios.post("/modelSelect/getModelDetail", {
-        modelId: item.imageModel,
-      });
-    }
-    if (item.videoModel) {
-      await axios.post("/modelSelect/getModelDetail", {
-        modelId: item.videoModel,
-      });
-    }
-  } catch {
-    window.$message.warning($t("workbench.project.msg.modelProviderDisabled"));
-    return openEdit(item);
-  }
-
   project.value = item;
   if (item.projectType === "novel") router.push(`/novel`);
   else if (item.projectType === "script") router.push(`/script`);

--- a/tests/manualMediaMode.test.mjs
+++ b/tests/manualMediaMode.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+const liveMediaFiles = [
+  "src/views/assets/components/generateImage.vue",
+  "src/views/assets/components/batchGeneration.vue",
+  "src/views/assets/index.vue",
+  "src/views/cornerScape/index.vue",
+  "src/stores/productionAgent.ts",
+  "src/views/production/node/storyboard.vue",
+  "src/views/production/components/editImage/generatedNode.vue",
+  "src/views/production/components/workbench/generate/index.vue",
+  "src/views/production/components/workbench/generate/components/track.vue",
+  "src/components/setting/components/vendorTest/ImageModelTest.vue",
+  "src/components/setting/components/vendorTest/VideoModelTest.vue",
+];
+
+const forbiddenEndpoints = [
+  "/assetsGenerate/generateAssets",
+  "/assetsGenerate/batchGenerateImageAssets",
+  "/production/assets/batchGenerateAssetsImage",
+  "/production/storyboard/batchGenerateImage",
+  "/production/editImage/generateFlowImage",
+  "/production/workbench/generateVideo",
+  "/production/workbench/batchGenerateVideo",
+];
+
+test("manual media helper builds complete prompts and supports clipboard copy", () => {
+  const source = read("src/utils/manualMedia.ts");
+
+  assert.match(source, /buildManualImagePrompt/);
+  assert.match(source, /buildManualVideoPrompt/);
+  assert.match(source, /buildBatchPrompt/);
+  assert.match(source, /navigator\.clipboard\.writeText/);
+});
+
+test("live image and video workflows do not call media generation endpoints", () => {
+  for (const relativePath of liveMediaFiles) {
+    const source = read(relativePath);
+    for (const endpoint of forbiddenEndpoints) {
+      const hasExactEndpoint = [`"${endpoint}"`, `'${endpoint}'`, `\`${endpoint}\``].some((literal) => source.includes(literal));
+      assert.ok(!hasExactEndpoint, `${relativePath} still calls ${endpoint}`);
+    }
+  }
+});
+
+test("image and video result positions expose manual upload actions", () => {
+  const imageDialog = read("src/views/assets/components/generateImage.vue");
+  const generatedNode = read("src/views/production/components/editImage/generatedNode.vue");
+  const videoCard = read("src/views/production/components/workbench/generate/components/video.vue");
+  const imageModelTest = read("src/components/setting/components/vendorTest/ImageModelTest.vue");
+  const videoModelTest = read("src/components/setting/components/vendorTest/VideoModelTest.vue");
+
+  assert.match(imageDialog, /copyManualPrompt/);
+  assert.match(imageDialog, /handleCustomUpload/);
+  assert.match(generatedNode, /copyManualPrompt/);
+  assert.match(generatedNode, /lensImage/);
+  assert.match(videoCard, /uploadVideo/);
+  assert.match(videoCard, /\/production\/workbench\/uploadVideo/);
+  assert.match(imageModelTest, /uploadResultImage/);
+  assert.match(videoModelTest, /uploadResultVideo/);
+});

--- a/tests/manualProjectModelSelection.test.mjs
+++ b/tests/manualProjectModelSelection.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+test("project dialog does not render or require media model settings in manual media mode", () => {
+  const source = read("src/views/project/components/projectDialog.vue");
+
+  assert.doesNotMatch(source, /<modelSelect\b/);
+  assert.doesNotMatch(source, /workbench\.project\.dialog\.modelData/);
+  assert.doesNotMatch(source, /workbench\.project\.dialog\.videoModelData/);
+  assert.doesNotMatch(source, /enterImageModel|enterVideoModel|enterProjectQuality|selectMode/);
+  assert.doesNotMatch(source, /\/modelSelect\/getModelDetail/);
+});
+
+test("project payload keeps legacy media fields as optional compatibility values", () => {
+  const source = read("src/views/project/components/projectDialog.vue");
+
+  assert.match(source, /imageModel:\s*formState\.value\.imageModel/);
+  assert.match(source, /videoModel:\s*formState\.value\.videoModel/);
+  assert.match(source, /imageQuality:\s*formState\.value\.imageQuality/);
+  assert.match(source, /mode:\s*formState\.value\.mode/);
+});
+
+test("opening a project does not check media model providers", () => {
+  const source = read("src/views/project/index.vue");
+  const openProject = source.slice(source.indexOf("async function openProject"), source.indexOf("function openEdit"));
+
+  assert.doesNotMatch(openProject, /imageModel|videoModel/);
+  assert.doesNotMatch(openProject, /\/modelSelect\/getModelDetail/);
+  assert.doesNotMatch(openProject, /modelProviderDisabled/);
+  assert.match(openProject, /project\.value\s*=\s*item/);
+  assert.match(openProject, /router\.push/);
+});

--- a/tests/storyboardTableCompleteness.test.mjs
+++ b/tests/storyboardTableCompleteness.test.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { appendThinkingDelta } from "../src/utils/useChat.ts";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
@@ -24,4 +25,35 @@ test("storyboard table state only commits a genuinely closed XML response", () =
   assert.match(handler, /const \{[^}]*isComplete[^}]*\} = data/);
   assert.match(handler, /tag === "storyboardTable"[\s\S]*isComplete && status === "complete"/);
   assert.match(handler, /flowData\.value\.storyboardTable = value \?\? ""/);
+});
+
+test("execution director thinking is expanded without changing other agents", () => {
+  const chatSource = read("src/utils/useChat.ts");
+  const storeSource = read("src/stores/productionAgent.ts");
+
+  assert.match(chatSource, /defaultThinkingCollapsed\?:\s*boolean\s*\|\s*\(\(message:\s*ChatMessagesData\)\s*=>\s*boolean\)/);
+  assert.match(chatSource, /collapsed:\s*resolveDefaultThinkingCollapsed\(msg\)/);
+  assert.doesNotMatch(chatSource, /name\s*===\s*["']执行导演["']/);
+
+  assert.match(storeSource, /function\s+isExecutionDirectorMessage[\s\S]*name\s*===\s*"执行导演"/);
+  assert.match(storeSource, /defaultThinkingCollapsed:\s*\(message\)\s*=>\s*!isExecutionDirectorMessage\(message\)/);
+  assert.match(storeSource, /data\.map\(expandExecutionDirectorThinking\)/);
+  assert.match(storeSource, /collapsed:\s*false/);
+});
+
+test("thinking reasoning deltas append to the complete accumulated text", () => {
+  const source = read("src/utils/useChat.ts");
+  const deltas = ["正", "在", "读取剧本"];
+  const snapshots = [];
+  let thinking = { title: "思考中...", text: "" };
+
+  for (const text of deltas) {
+    thinking = appendThinkingDelta(thinking, { text });
+    snapshots.push(thinking.text);
+  }
+
+  assert.match(source, /content\.type\s*===\s*["']thinking["'][\s\S]*strategy\s*===\s*["']append["']/);
+  assert.match(source, /content\.data\s*=\s*appendThinkingDelta\(content\.data,\s*data\)/);
+  assert.deepEqual(snapshots, ["正", "正在", "正在读取剧本"]);
+  assert.deepEqual(thinking, { title: "思考中...", text: "正在读取剧本" });
 });

--- a/tests/storyboardTableCompleteness.test.mjs
+++ b/tests/storyboardTableCompleteness.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), "utf8");
+
+test("XML events expose real closing-tag completeness", () => {
+  const source = read("src/utils/useChat.ts");
+
+  assert.match(source, /isComplete:\s*boolean/);
+  assert.match(source, /status === "complete"\s*\?\s*"error"/);
+  assert.match(source, /isComplete,\s*\n\s*status:\s*eventStatus/);
+});
+
+test("storyboard table state only commits a genuinely closed XML response", () => {
+  const source = read("src/stores/productionAgent.ts");
+  const handlerStart = source.indexOf("onXmlTag: async");
+  const handlerEnd = source.indexOf("});", handlerStart);
+  const handler = source.slice(handlerStart, handlerEnd);
+
+  assert.match(handler, /const \{[^}]*isComplete[^}]*\} = data/);
+  assert.match(handler, /tag === "storyboardTable"[\s\S]*isComplete && status === "complete"/);
+  assert.match(handler, /flowData\.value\.storyboardTable = value \?\? ""/);
+});


### PR DESCRIPTION
## What changed

- Replace image and video generation actions with complete prompt copy actions.
- Keep text-model prompt generation and polishing unchanged.
- Preserve existing image upload flows and add video upload at the original video card.
- Support numbered batch prompt copying for assets, storyboards, and video tracks.
- Update image/video provider test dialogs to copy prompts and preview uploaded external results.
- Add focused manual-media workflow tests.

## Why

Users will generate media in external tools, then return to Toonflow and upload the result without changing the existing asset, storyboard, or video-selection flow.

## Validation

- `node --test tests/manualMediaMode.test.mjs` — 3/3 passed
- Vite production build — passed (11097 modules)
- modified files introduced no new type errors

The repository's full type check remains blocked by pre-existing errors in historical `copy.vue` files and unrelated baseline types; these are documented rather than hidden.
